### PR TITLE
#25 [feat] GET - 글 해당 댓글 리스트 조회 구현

### DIFF
--- a/module-api/src/main/java/com/mile/controller/post/PostController.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostController.java
@@ -4,8 +4,10 @@ import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
 import com.mile.post.service.PostService;
 import com.mile.post.service.dto.CommentCreateRequest;
+import com.mile.post.service.dto.CommentListResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,7 +19,7 @@ import java.security.Principal;
 @RestController
 @RequestMapping("/api/post")
 @RequiredArgsConstructor
-public class PostController implements PostControllerSwagger{
+public class PostController implements PostControllerSwagger {
 
     private final PostService postService;
 
@@ -34,5 +36,14 @@ public class PostController implements PostControllerSwagger{
                 commentCreateRequest
         );
         return SuccessResponse.of(SuccessMessage.COMMENT_CREATE_SUCCESS);
+    }
+
+    @GetMapping("/{postId}/comment")
+    @Override
+    public SuccessResponse<CommentListResponse> getComments(
+            @PathVariable final Long postId,
+            final Principal principal
+    ) {
+        return SuccessResponse.of(SuccessMessage.COMMENT_SEARCH_SUCCESS, postService.getComments(postId, Long.valueOf(principal.getName())));
     }
 }

--- a/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
@@ -43,8 +43,10 @@ public interface PostControllerSwagger {
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "200", description = "댓글 조회가 완료되었습니다."),
-                    @ApiResponse(responseCode = "403", description = "해당 사용자는 모임에 접근 권한이 없습니다."),
-                    @ApiResponse(responseCode = "404", description = "해당 글에 대한 댓글이 존재하지 않습니다."),
+                    @ApiResponse(responseCode = "403", description = "해당 사용자는 모임에 접근 권한이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 글에 대한 댓글이 존재하지 않습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }

--- a/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
@@ -3,6 +3,7 @@ package com.mile.controller.post;
 import com.mile.dto.ErrorResponse;
 import com.mile.dto.SuccessResponse;
 import com.mile.post.service.dto.CommentCreateRequest;
+import com.mile.post.service.dto.CommentListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -35,6 +36,21 @@ public interface PostControllerSwagger {
     SuccessResponse postComment(
             @PathVariable final Long postId,
             @Valid @RequestBody final CommentCreateRequest commentCreateRequest,
+            final Principal principal
+    );
+
+    @Operation(summary = "댓글 리스트 조회")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "댓글 조회가 완료되었습니다."),
+                    @ApiResponse(responseCode = "403", description = "해당 사용자는 모임에 접근 권한이 없습니다."),
+                    @ApiResponse(responseCode = "404", description = "해당 글에 대한 댓글이 존재하지 않습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    SuccessResponse<CommentListResponse> getComments(
+            @PathVariable final Long postId,
             final Principal principal
     );
 }

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -14,7 +14,7 @@ public enum ErrorMessage {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 유저는 존재하지 않습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 유저의 리프레시 토큰이 존재하지 않습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글은 존재하지 않습니다."),
-
+    COMMENTS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글에 대한 댓글이 존재하지 않습니다."),
     MOIM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글모임이 존재하지 않습니다."),
     CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 모임의 주제가 존재하지 않습니다."),
     HANDLER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "요청하신 URL은 정보가 없습니다."),
@@ -25,9 +25,7 @@ public enum ErrorMessage {
     ENUM_VALUE_BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "요청한 값이 유효하지 않습니다."),
     AUTHENTICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST.value(), "인가 코드가 만료되었습니다."),
     SOCIAL_TYPE_BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "로그인 요청이 유효하지 않습니다."),
-
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "요청 값이 유효하지 않습니다."),
-
     BEARER_LOST_ERROR(HttpStatus.BAD_REQUEST.value(), "토큰의 요청에 Bearer이 담겨 있지 않습니다."),
 
     /*

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -11,14 +11,12 @@ public enum SuccessMessage {
     ISSUE_ACCESS_TOKEN_SUCCESS(HttpStatus.OK.value(), "액세스 토큰 재발급이 완료되었습니다."),
     USER_DELETE_SUCCESS(HttpStatus.OK.value(), "회원 삭제가 완료되었습니다."),
     LOGOUT_SUCCESS(HttpStatus.OK.value(), "로그아웃이 완료되었습니다."),
-
+    TOPIC_SEARCH_SUCCESS(HttpStatus.OK.value(), "주제 조회가 완료되었습니다."),
+    COMMENT_SEARCH_SUCCESS(HttpStatus.OK.value(), "댓글 조회가 완료되었습니다."),
     /*
     201 CREATED
      */
     COMMENT_CREATE_SUCCESS(HttpStatus.CREATED.value(), "댓글 등록이 완료되었습니다."),
-
-
-    TOPIC_SEARCH_SUCCESS(HttpStatus.OK.value(), "주제 조회가 완료되었습니다."),
     ;
 
     int status;

--- a/module-domain/src/main/java/com/mile/comment/domain/Comment.java
+++ b/module-domain/src/main/java/com/mile/comment/domain/Comment.java
@@ -4,6 +4,7 @@ import com.mile.config.BaseTimeEntity;
 import com.mile.post.domain.Post;
 import com.mile.post.service.dto.CommentCreateRequest;
 import com.mile.user.domain.User;
+import com.mile.writerName.domain.WriterName;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -12,9 +13,11 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
@@ -30,11 +33,11 @@ public class Comment extends BaseTimeEntity {
     private boolean anonymous;
 
     @ManyToOne
-    private User user;
+    private WriterName writerName;
 
     public static Comment create(
             final Post post,
-            final User user,
+            final WriterName writerName,
             final CommentCreateRequest createRequest,
             final boolean anonymous
     ) {
@@ -42,7 +45,7 @@ public class Comment extends BaseTimeEntity {
                 .builder()
                 .post(post)
                 .content(createRequest.content())
-                .user(user)
+                .writerName(writerName)
                 .anonymous(anonymous)
                 .build();
     }

--- a/module-domain/src/main/java/com/mile/comment/repository/CommentRepository.java
+++ b/module-domain/src/main/java/com/mile/comment/repository/CommentRepository.java
@@ -3,5 +3,9 @@ package com.mile.comment.repository;
 import com.mile.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findByPostId(final Long postId);
 }

--- a/module-domain/src/main/java/com/mile/comment/service/CommentService.java
+++ b/module-domain/src/main/java/com/mile/comment/service/CommentService.java
@@ -2,23 +2,63 @@ package com.mile.comment.service;
 
 import com.mile.comment.domain.Comment;
 import com.mile.comment.repository.CommentRepository;
+import com.mile.comment.service.dto.CommentResponse;
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.NotFoundException;
 import com.mile.post.domain.Post;
+import com.mile.post.service.PostAuthenticateService;
 import com.mile.post.service.dto.CommentCreateRequest;
 import com.mile.user.domain.User;
+import com.mile.writerName.domain.WriterName;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
     private static boolean ANONYMOUS_TRUE = true;
     private final CommentRepository commentRepository;
+    private final PostAuthenticateService postAuthenticateService;
 
     public void createComment(
             final Post post,
-            final User user,
+            final WriterName writerName,
             final CommentCreateRequest commentCreateRequest
     ) {
-        commentRepository.save(Comment.create(post, user, commentCreateRequest, ANONYMOUS_TRUE));
+        commentRepository.save(Comment.create(post, writerName, commentCreateRequest, ANONYMOUS_TRUE));
+    }
+
+    public List<CommentResponse> getCommentResponse(
+            final Long postId,
+            final Long userId
+    ) {
+        postAuthenticateService.authenticateUserWithPostId(postId, userId);
+        List<Comment> commentList = findById(postId);
+        throwIfCommentIsNull(commentList);
+        return commentList.stream()
+                .map(comment -> CommentResponse.of(comment, userId)).collect(Collectors.toList());
+    }
+
+    private List<Comment> findById(
+            final Long postId
+    ) {
+        return commentRepository.findByPostId(postId);
+    }
+
+    private void throwIfCommentIsNull(
+            final List<Comment> commentList
+    ) {
+        if (isCommentListNull(commentList)) {
+            throw new NotFoundException(ErrorMessage.COMMENTS_NOT_FOUND);
+        }
+    }
+
+    private boolean isCommentListNull(
+            final List<Comment> commentList
+    ) {
+        return commentList.isEmpty();
     }
 }

--- a/module-domain/src/main/java/com/mile/comment/service/dto/CommentResponse.java
+++ b/module-domain/src/main/java/com/mile/comment/service/dto/CommentResponse.java
@@ -1,0 +1,28 @@
+package com.mile.comment.service.dto;
+
+import com.mile.comment.domain.Comment;
+import com.mile.writerName.domain.WriterName;
+
+public record CommentResponse(
+    Long commentId,
+    String name,
+    String moimName,
+    String content,
+    boolean isMyComment
+) {
+    private static String ANONYMOUS = "작자미상";
+
+    public static CommentResponse of(
+            final Comment comment,
+            final Long userId
+    ) {
+        WriterName writerName = comment.getWriterName();
+        return new CommentResponse(
+                comment.getId(),
+                ANONYMOUS + writerName.getId().toString(),
+                writerName.getMoim().getName(),
+                comment.getContent(),
+                writerName.getId().equals(userId)
+                );
+    }
+}

--- a/module-domain/src/main/java/com/mile/post/service/PostAuthenticateService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostAuthenticateService.java
@@ -19,8 +19,7 @@ public class PostAuthenticateService {
             final Long userId
     ) {
         Post post = findById(postId);
-        Long moimId = post.getTopic().getMoim().getId();
-        moimService.authenticateUserOfMoim(moimId, userId);
+        authenticateUserWithPost(post, userId);
     }
 
     public void authenticateUserWithPost(

--- a/module-domain/src/main/java/com/mile/post/service/PostAuthenticateService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostAuthenticateService.java
@@ -1,0 +1,42 @@
+package com.mile.post.service;
+
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.NotFoundException;
+import com.mile.moim.serivce.MoimService;
+import com.mile.post.domain.Post;
+import com.mile.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostAuthenticateService {
+    private final MoimService moimService;
+    private final PostRepository postRepository;
+
+    public void authenticateUserWithPostId(
+            final Long postId,
+            final Long userId
+    ) {
+        Post post = findById(postId);
+        Long moimId = post.getTopic().getMoim().getId();
+        moimService.authenticateUserOfMoim(moimId, userId);
+    }
+
+    public void authenticateUserWithPost(
+            final Post post,
+            final Long userId
+    ) {
+        Long moimId = post.getTopic().getMoim().getId();
+        moimService.authenticateUserOfMoim(moimId, userId);
+    }
+
+    private Post findById(
+            final Long postId
+    ) {
+        return postRepository.findById(postId)
+                .orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.POST_NOT_FOUND)
+                );
+    }
+}

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -7,7 +7,9 @@ import com.mile.moim.serivce.MoimService;
 import com.mile.post.domain.Post;
 import com.mile.post.repository.PostRepository;
 import com.mile.post.service.dto.CommentCreateRequest;
+import com.mile.post.service.dto.CommentListResponse;
 import com.mile.user.serivce.UserService;
+import com.mile.writerName.serivce.WriterNameService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,9 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
     private final PostRepository postRepository;
-    private final MoimService moimService;
+    private final PostAuthenticateService postAuthenticateService;
     private final CommentService commentService;
-    private final UserService userService;
+    private final WriterNameService writerNameService;
 
     @Transactional
     public void createCommentOnPost(
@@ -29,17 +31,18 @@ public class PostService {
 
     ) {
         Post post = findById(postId);
-        authenticateUserWithPost(post, userId);
-        commentService.createComment(post, userService.findById(userId), commentCreateRequest);
+        Long moimId = post.getTopic().getMoim().getId();
+        postAuthenticateService.authenticateUserWithPost(post, userId);
+        commentService.createComment(post, writerNameService.findByMoimAndUser(moimId, userId), commentCreateRequest);
     }
 
-
-    private void authenticateUserWithPost(
-            final Post post,
+    public CommentListResponse getComments(
+            final Long postId,
             final Long userId
     ) {
-        moimService.authenticateUserOfMoim(post.getTopic().getMoim().getId(), userId);
+        return CommentListResponse.of(commentService.getCommentResponse(postId, userId));
     }
+
 
     public Post findById(
             final Long postId

--- a/module-domain/src/main/java/com/mile/post/service/dto/CommentListResponse.java
+++ b/module-domain/src/main/java/com/mile/post/service/dto/CommentListResponse.java
@@ -1,0 +1,14 @@
+package com.mile.post.service.dto;
+
+import com.mile.comment.service.dto.CommentResponse;
+import java.util.List;
+
+public record CommentListResponse (
+        List<CommentResponse> comments
+){
+    public static CommentListResponse of(
+            final List<CommentResponse> commentResponseList
+    ) {
+        return new CommentListResponse(commentResponseList);
+    }
+}

--- a/module-domain/src/main/java/com/mile/writerName/serivce/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writerName/serivce/WriterNameService.java
@@ -1,8 +1,12 @@
 package com.mile.writerName.serivce;
 
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.NotFoundException;
+import com.mile.writerName.domain.WriterName;
 import com.mile.writerName.repository.WriterNameRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
 
 @Service
 @RequiredArgsConstructor
@@ -16,4 +20,13 @@ public class WriterNameService {
         return writerNameRepository.findByMoimIdAndWriterId(moimId, writerId).isPresent();
     }
 
+    public WriterName findByMoimAndUser(
+            final Long moimId,
+            final Long writerId
+    ) {
+        return writerNameRepository.findByMoimIdAndWriterId(moimId, writerId)
+                .orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.USER_AUTHENTICATE_ERROR)
+                );
+    }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #25 

## Key Changes 🔑
1. 스웨거 작업해주었습니다!
![image](https://github.com/Mile-Writings/Mile-Server/assets/79795051/23fcbb8e-583c-4f79-a4be-2db1be6e7578)
2. `Comment` 내부 연관관계를 `User`에서 `WriterName`으로 변경했습니다!
   - 기존에 실명 <-> 익명 제도여서 User로 엮어뒀었는데 필명 <-> 익명제도로 변경되었고, 이 모임에 대한 권한이 있는지 확인하는 플로우가 자주 사용되니 `WriterName`으로 변경하는게 적합하다고 판단했습니다! 혹시 의견있으면 남겨주세요!
3. `PostAuthenticateService`와 `PostService` 분리
  - `CommentService`에서 해당 post에 대한 댓글 권한이 있는지 확인하는 플로우에서 `PostService` 를 참조해야 했는데, 이미 `PostService`에서 `CommentService`를 참조하고 있어순환 참조 문제가 발생하고, 또한 PostService의 역할이 커지는 것 같아 검증과 관련된 메소드는 `PostAuthenticateService`를 따로 두어 역할을 분리해주었습니다.
## To Reviewers 📢
- 아자잣!
