### PR TITLE
#30 [feat]  모임에 대한 권한 확인

### DIFF
--- a/module-api/src/main/java/com/mile/controller/moim/MoimController.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimController.java
@@ -27,4 +27,13 @@ public class MoimController implements MoimControllerSwagger {
     ) {
         return SuccessResponse.of(SuccessMessage.TOPIC_SEARCH_SUCCESS, moimService.getContentsFromMoim(moimId, Long.valueOf(principal.getName())));
     }
+
+    @GetMapping("/{moimId}/authenticate")
+    @Override
+    public SuccessResponse getAuthenticationOfMoim(
+            final Long moimId,
+            final Principal principal
+    ) {
+        return SuccessResponse.of(SuccessMessage.MOIM_AUTHENTICATE_SUCCESS, moimService.getAuthenticateUserOfMoim(moimId, Long.valueOf(principal.getName())));
+    }
 }

--- a/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
@@ -31,4 +31,20 @@ public interface MoimControllerSwagger {
             @PathVariable final Long moimId,
             final Principal principal
     );
+
+
+    @Operation(summary = "댓글 및 궁금해요 기능 권한 조회 API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "사용자의 권한이 확인되었습니다."),
+                    @ApiResponse(responseCode = "403", description = "사용자 검증 토큰이 유효하지 안습니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+                    ),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    SuccessResponse getAuthenticationOfMoim(
+            final Long moimId,
+            final Principal principal
+    );
 }

--- a/module-common/src/main/java/com/mile/authentication/CustomJwtAuthenticationEntryPoint.java
+++ b/module-common/src/main/java/com/mile/authentication/CustomJwtAuthenticationEntryPoint.java
@@ -1,20 +1,35 @@
 package com.mile.authentication;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mile.dto.ErrorResponse;
+import com.mile.exception.message.ErrorMessage;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
+
 @Component
+@RequiredArgsConstructor
 public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) {
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         setResponse(response);
     }
 
-    private void setResponse(HttpServletResponse response) {
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    private void setResponse(HttpServletResponse response) throws IOException {
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorMessage.TOKEN_VALIDATION_ERROR);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 
 }

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -14,6 +14,7 @@ public enum SuccessMessage {
     LOGOUT_SUCCESS(HttpStatus.OK.value(), "로그아웃이 완료되었습니다."),
     TOPIC_SEARCH_SUCCESS(HttpStatus.OK.value(), "주제 조회가 완료되었습니다."),
     COMMENT_SEARCH_SUCCESS(HttpStatus.OK.value(), "댓글 조회가 완료되었습니다."),
+    MOIM_AUTHENTICATE_SUCCESS(HttpStatus.OK.value(), "사용자의 권한이 확인되었습니다."),
     /*
     201 CREATED
      */

--- a/module-domain/src/main/java/com/mile/moim/serivce/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/serivce/MoimService.java
@@ -3,6 +3,7 @@ package com.mile.moim.serivce;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.ForbiddenException;
 import com.mile.moim.serivce.dto.ContentListResponse;
+import com.mile.moim.serivce.dto.MoimAuthenticateResponse;
 import com.mile.topic.serivce.TopicService;
 import com.mile.writerName.serivce.WriterNameService;
 import lombok.RequiredArgsConstructor;
@@ -29,5 +30,12 @@ public class MoimService {
         if (!writerNameService.isUserInMoim(moimId, userId)) {
             throw new ForbiddenException(ErrorMessage.USER_AUTHENTICATE_ERROR);
         }
+    }
+
+    public MoimAuthenticateResponse getAuthenticateUserOfMoim(
+            final Long moimId,
+            final Long userId
+    ) {
+        return MoimAuthenticateResponse.of(writerNameService.isUserInMoim(moimId, userId));
     }
 }

--- a/module-domain/src/main/java/com/mile/moim/serivce/dto/MoimAuthenticateResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/serivce/dto/MoimAuthenticateResponse.java
@@ -4,7 +4,7 @@ public record MoimAuthenticateResponse(
         boolean isMember
 ) {
     public static MoimAuthenticateResponse of(
-            boolean isMember
+            final boolean isMember
     ) {
         return new MoimAuthenticateResponse(isMember);
     }

--- a/module-domain/src/main/java/com/mile/moim/serivce/dto/MoimAuthenticateResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/serivce/dto/MoimAuthenticateResponse.java
@@ -1,0 +1,11 @@
+package com.mile.moim.serivce.dto;
+
+public record MoimAuthenticateResponse(
+        boolean isMember
+) {
+    public static MoimAuthenticateResponse of(
+            boolean isMember
+    ) {
+        return new MoimAuthenticateResponse(isMember);
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #30 

## Key Changes 🔑
1. jwt 토큰으로 인증을 하고 security filter chain에서 걸릴 경우 에러 메시지 없이 빈 화면이 발생하는 것을 EntryPoint에서 커스텀 해주었습니다!
2. 마련되어 있는 메서드 활용하여 구현했습니다! 
3. 스웨거 작성했습니다!
1. 
![image](https://github.com/Mile-Writings/Mile-Server/assets/79795051/6626bfdd-b23e-437f-8b7e-092d9bccc5fa)
2. 
![image](https://github.com/Mile-Writings/Mile-Server/assets/79795051/e026ba42-d5a6-4dc1-a7a0-cc2f3e6c8468)
3.
![image](https://github.com/Mile-Writings/Mile-Server/assets/79795051/0cb98dc3-e47f-4239-9238-017ca1c874e5)


## To Reviewers 📢
- 코드 이상한 점 알려주세요!
