### PR TITLE
#41 [feat] 글 삭제 구현

### DIFF
--- a/module-api/src/main/java/com/mile/controller/post/PostController.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostController.java
@@ -9,6 +9,7 @@ import com.mile.post.service.dto.CommentListResponse;
 import com.mile.post.service.dto.PostPutRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,6 +24,7 @@ import java.security.Principal;
 @RestController
 @RequestMapping("/api/post")
 @RequiredArgsConstructor
+@Slf4j
 public class PostController implements PostControllerSwagger {
 
     private final PostService postService;
@@ -100,5 +102,15 @@ public class PostController implements PostControllerSwagger {
     ) {
         postService.updatePost(postId, Long.valueOf(principal.getName()), putRequest);
         return SuccessResponse.of(SuccessMessage.POST_PUT_SUCCESS);
+    }
+
+    @DeleteMapping("/{postId}")
+    @Override
+    public SuccessResponse deletePost(
+            @PathVariable final Long postId,
+            final Principal principal
+    ) {
+        postService.deletePost(postId, Long.valueOf(principal.getName()));
+        return SuccessResponse.of(SuccessMessage.POST_DELETE_SUCCESS);
     }
 }

--- a/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
@@ -144,4 +144,21 @@ public interface PostControllerSwagger {
             @RequestBody final PostPutRequest putRequest,
             final Principal principal
     );
+
+    @Operation(summary = "글 삭제")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "글 삭제가 완료되었습니다."),
+                    @ApiResponse(responseCode = "404", description = "해당 글은 존재하지 않습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "해당 사용자는 글 수정/삭제 권한이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    SuccessResponse deletePost(
+            @PathVariable final Long postId,
+            final Principal principal
+    );
 }

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -19,6 +19,7 @@ public enum SuccessMessage {
     CURIOUS_DELETE_SUCCESS(HttpStatus.OK.value(), "궁금해요 삭제가 완료되었습니다."),
     WRITER_AUTHENTIACTE_SUCCESS(HttpStatus.OK.value(), "게시글 권한이 확인되었습니다."),
     POST_PUT_SUCCESS(HttpStatus.OK.value(), "글 수정이 완료되었습니다."),
+    POST_DELETE_SUCCESS(HttpStatus.OK.value(), "글 삭제가 완료되었습니다."),
     /*
     201 CREATED
      */

--- a/module-domain/build.gradle
+++ b/module-domain/build.gradle
@@ -4,6 +4,7 @@ jar { enabled = true }
 dependencies {
     implementation project(':module-auth')
     implementation project(':module-common')
+    implementation project(':module-external')
 
     //Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'

--- a/module-domain/src/main/java/com/mile/comment/repository/CommentRepository.java
+++ b/module-domain/src/main/java/com/mile/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.mile.comment.repository;
 
 import com.mile.comment.domain.Comment;
+import com.mile.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +14,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Long findUserIdByComment(@Param(value = "comment") final Comment comment);
 
     List<Comment> findByPostId(final Long postId);
+
+    void deleteAllByPost(final Post post);
 }

--- a/module-domain/src/main/java/com/mile/comment/service/CommentService.java
+++ b/module-domain/src/main/java/com/mile/comment/service/CommentService.java
@@ -95,4 +95,10 @@ public class CommentService {
     ) {
         return commentList.isEmpty();
     }
+
+    public void deleteAllByPost(
+            final Post post
+    ) {
+        commentRepository.deleteAllByPost(post);
+    }
 }

--- a/module-domain/src/main/java/com/mile/curious/repository/CuriousRepository.java
+++ b/module-domain/src/main/java/com/mile/curious/repository/CuriousRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CuriousRepository extends JpaRepository<Curious, Long> {
     boolean existsByPostAndUser(Post post, User user);
     Curious findByPostAndUser(Post post, User user);
+
+    void deleteAllByPost(final Post post);
 }

--- a/module-domain/src/main/java/com/mile/curious/serivce/CuriousService.java
+++ b/module-domain/src/main/java/com/mile/curious/serivce/CuriousService.java
@@ -1,10 +1,11 @@
 package com.mile.curious.serivce;
+
+import com.mile.curious.domain.Curious;
 import com.mile.curious.repository.CuriousRepository;
 import com.mile.curious.serivce.dto.CuriousInfoResponse;
 import com.mile.exception.message.ErrorMessage;
-import com.mile.exception.model.NotFoundException;
-import com.mile.curious.domain.Curious;
 import com.mile.exception.model.ConflictException;
+import com.mile.exception.model.NotFoundException;
 import com.mile.post.domain.Post;
 import com.mile.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -43,5 +44,11 @@ public class CuriousService {
 
     public CuriousInfoResponse getCuriousInfoResponse(final Post post, final User user) {
         return CuriousInfoResponse.of(curiousRepository.existsByPostAndUser(post, user), post.getCuriousCount());
+    }
+
+    public void deleteAllByPost(
+            final Post post
+    ) {
+        curiousRepository.deleteAllByPost(post);
     }
 }

--- a/module-domain/src/main/java/com/mile/post/domain/Post.java
+++ b/module-domain/src/main/java/com/mile/post/domain/Post.java
@@ -24,8 +24,8 @@ public class Post extends BaseTimeEntity {
     private String imageUrl;
     @ManyToOne
     private WriterName writerName;
-
     private int curiousCount;
+    private boolean containPhoto;
     private boolean anonymous;
     private boolean isTemporary;
 

--- a/module-external/src/main/java/com/mile/aws/utils/S3Service.java
+++ b/module-external/src/main/java/com/mile/aws/utils/S3Service.java
@@ -89,7 +89,7 @@ public class S3Service {
     }
 
     // S3 버킷에 업로드된 이미지 삭제
-    public void deleteImage(final String key) throws IOException {
+    public void deleteImage(final String key) {
         try {
             final S3Client s3Client = awsConfig.getS3Client();
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #41 

## Key Changes 🔑
1. 스웨거 작성하였습니다
<img width="1286" alt="image" src="https://github.com/Mile-Writings/Mile-Server/assets/79795051/046634e2-7da6-4aaf-80c1-2c55db469729">

2. Post 엔티티에 boolean containPhoto 값 추가했습니다.

3. s3 delete 모듈도 연동했습니다.

4. 삭제할 때 댓글, 궁금해요 엔티티도 함께 삭제해줘야 하기 때문에 함께 삭제 구현했습니다.

## To Reviewers 📢
- 코드 수정사항 있으면 알려주세요!
