### PR TITLE
#45 [feat] 소셜 로그인 Refresh Token Http-Only 쿠키 반환

### DIFF
--- a/module-api/src/main/java/com/mile/controller/user/UserController.java
+++ b/module-api/src/main/java/com/mile/controller/user/UserController.java
@@ -7,7 +7,11 @@ import com.mile.token.service.TokenService;
 import com.mile.user.service.UserService;
 import com.mile.user.service.dto.AccessTokenGetSuccess;
 import com.mile.user.service.dto.LoginSuccessResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,17 +29,29 @@ public class UserController implements UserControllerSwagger {
 
     private final UserService userService;
     private final TokenService tokenService;
+    private final static int COOKIE_MAX_AGE = 7 * 24 * 60 * 60;
+    private final static String REFRESH_TOKEN = "refreshToken";
 
     @PostMapping("/login")
     @Override
-    public SuccessResponse<LoginSuccessResponse> login(
+    public ResponseEntity<SuccessResponse<AccessTokenGetSuccess>> login(
             @RequestParam final String authorizationCode,
-            @RequestBody final UserLoginRequest loginRequest
+            @RequestBody final UserLoginRequest loginRequest,
+            HttpServletResponse response
     ) {
-        return SuccessResponse.of(SuccessMessage.LOGIN_SUCCESS, userService.create(authorizationCode, loginRequest));
+        LoginSuccessResponse successResponse = userService.create(authorizationCode, loginRequest);
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN, successResponse.refreshToken())
+                .maxAge(COOKIE_MAX_AGE)
+                .path("/")
+                .secure(true)
+                .sameSite("None")
+                .httpOnly(true)
+                .build();
+        response.setHeader("Set-Cookie", cookie.toString());
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.of(SuccessMessage.LOGIN_SUCCESS, AccessTokenGetSuccess.of(successResponse.accessToken())));
     }
 
-    @GetMapping("/token-refresh")
+    @GetMapping("/token/reissue")
     @Override
     public SuccessResponse<AccessTokenGetSuccess> refreshToken(
             @RequestParam final String refreshToken
@@ -43,7 +59,7 @@ public class UserController implements UserControllerSwagger {
         return SuccessResponse.of(SuccessMessage.ISSUE_ACCESS_TOKEN_SUCCESS, userService.refreshToken(refreshToken));
     }
 
-    @DeleteMapping("/delete")
+    @DeleteMapping(" /delete")
     @Override
     public SuccessResponse deleteUser(
             final Principal principal

--- a/module-api/src/main/java/com/mile/controller/user/UserControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/user/UserControllerSwagger.java
@@ -11,6 +11,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -29,9 +31,10 @@ public interface UserControllerSwagger {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
-    SuccessResponse<LoginSuccessResponse> login(
+    ResponseEntity<SuccessResponse<AccessTokenGetSuccess>> login(
             @RequestParam final String authorizationCode,
-            @RequestBody final UserLoginRequest loginRequest
+            @RequestBody final UserLoginRequest loginRequest,
+            HttpServletResponse response
     );
 
     @Operation(summary = "액세스 토큰 재발급")

--- a/module-api/src/main/java/com/mile/controller/user/dto/AccessTokenGetSuccess.java
+++ b/module-api/src/main/java/com/mile/controller/user/dto/AccessTokenGetSuccess.java
@@ -1,0 +1,11 @@
+package com.mile.controller.user.dto;
+
+public record AccessTokenGetSuccess(
+        String accessToken
+) {
+    public static AccessTokenGetSuccess of(
+            final String accessToken
+    ) {
+        return new AccessTokenGetSuccess(accessToken);
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #45 

## Key Changes 🔑
1. 기존에 Response Body로 넘겨주던 Access Token과 Refresh Token을 탈취 방지를 위해서 Refresh Token은 Http-Only 헤더를 통해 반환하도록 수정했습니다!
 
## To Reviewers 📢
-  소셜 로그인 관련 헤더만 수정하고 이 외는 데모데이 이후에 클라이언트와 회의 후에 결정하겠습니다!
