### PR TITLE
#60 [feat] Scheduling 추천 글감

### DIFF
--- a/module-api/src/main/java/com/mile/controller/recommend/RecommendController.java
+++ b/module-api/src/main/java/com/mile/controller/recommend/RecommendController.java
@@ -1,0 +1,24 @@
+package com.mile.controller.recommend;
+
+import com.mile.dto.SuccessResponse;
+import com.mile.exception.message.SuccessMessage;
+import com.mile.recommend.service.RecommendService;
+import com.mile.recommend.service.dto.RecommendResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/recommend")
+@RequiredArgsConstructor
+public class RecommendController implements RecommendControllerSwagger{
+
+    private final RecommendService recommendService;
+
+    @Override
+    @GetMapping("/topic")
+    public SuccessResponse<RecommendResponse> getRecommendationDaily() {
+        return SuccessResponse.of(SuccessMessage.RECOMMENDATION_GET_SUCCESS, recommendService.getRandomRecommendation());
+    }
+}

--- a/module-api/src/main/java/com/mile/controller/recommend/RecommendControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/recommend/RecommendControllerSwagger.java
@@ -1,0 +1,26 @@
+package com.mile.controller.recommend;
+
+import com.mile.dto.ErrorResponse;
+import com.mile.dto.SuccessResponse;
+import com.mile.recommend.service.dto.RecommendResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Recommend Topic", description = "메인 뷰 글감 추천 API")
+public interface RecommendControllerSwagger {
+    @Operation(summary = "메인 뷰 글감 추천 API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "추천 글감이 조회되었습니다."),
+                    @ApiResponse(responseCode = "404", description = "추천 글감을 받아오는데 실패했습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    SuccessResponse<RecommendResponse> getRecommendationDaily();
+}

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -22,6 +22,7 @@ public enum ErrorMessage {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 댓글이 존재하지 않습니다."),
     CURIOUS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 궁금해요는 존재하지 않습니다."),
     TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 주제가 존재하지 않습니다."),
+    RECCOMEND_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "추천 글감을 받아오는데 실패했습니다."),
     /*
     Bad Request
      */

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -20,6 +20,7 @@ public enum SuccessMessage {
     WRITER_AUTHENTIACTE_SUCCESS(HttpStatus.OK.value(), "게시글 권한이 확인되었습니다."),
     POST_PUT_SUCCESS(HttpStatus.OK.value(), "글 수정이 완료되었습니다."),
     MOIM_INFO_SUCCESS(HttpStatus.OK.value(), "글모임 조회가 완료되었습니다."),
+    RECOMMENDATION_GET_SUCCESS(HttpStatus.OK.value(), "추천 글감이 조회되었습니다."),
     PRESIGNED_URL_GET_SUCCESS(HttpStatus.OK.value(), "이미지를 업로드할 url이 발행되었습니다."),
     POST_DELETE_SUCCESS(HttpStatus.OK.value(), "글 삭제가 완료되었습니다."),
     /*

--- a/module-domain/src/main/java/com/mile/recommend/domain/Recommend.java
+++ b/module-domain/src/main/java/com/mile/recommend/domain/Recommend.java
@@ -1,0 +1,18 @@
+package com.mile.recommend.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Recommend {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+}

--- a/module-domain/src/main/java/com/mile/recommend/repository/RecommendRepository.java
+++ b/module-domain/src/main/java/com/mile/recommend/repository/RecommendRepository.java
@@ -1,0 +1,7 @@
+package com.mile.recommend.repository;
+
+import com.mile.recommend.domain.Recommend;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecommendRepository extends JpaRepository<Recommend, Long> {
+}

--- a/module-domain/src/main/java/com/mile/recommend/service/RecommendService.java
+++ b/module-domain/src/main/java/com/mile/recommend/service/RecommendService.java
@@ -1,0 +1,34 @@
+package com.mile.recommend.service;
+
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.NotFoundException;
+import com.mile.recommend.repository.RecommendRepository;
+import com.mile.recommend.service.dto.RecommendResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendService {
+    private final RecommendRepository recommendRepository;
+    private static Long GROUND_ID = 0L;
+    private static final int INDEX = 1;
+
+    public RecommendResponse getRandomRecommendation() {
+        return RecommendResponse.of(getRandomContentDaily());
+    }
+    @Scheduled(cron = "0 0 0 * * *")
+    private String getRandomContentDaily() {
+        return recommendRepository.findById(GROUND_ID + INDEX).orElseGet(() -> {
+            resetGroundId();
+            return recommendRepository.findById(GROUND_ID + INDEX).orElseThrow(
+                    () -> new NotFoundException(ErrorMessage.RECCOMEND_NOT_FOUND)
+            );
+        }).getContent();
+    }
+
+    private void resetGroundId() {
+        GROUND_ID = 0L;
+    }
+}

--- a/module-domain/src/main/java/com/mile/recommend/service/dto/RecommendResponse.java
+++ b/module-domain/src/main/java/com/mile/recommend/service/dto/RecommendResponse.java
@@ -1,0 +1,9 @@
+package com.mile.recommend.service.dto;
+
+public record RecommendResponse(
+        String content
+) {
+    public static RecommendResponse of(final String content) {
+        return new RecommendResponse(content);
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #60 

## Key Changes 🔑
1. Recommend 클래스를 추가하여 추천 글감 엔티티를 만들어주었습니다!
2. Scheduled 어노테이션을 활용하여  자정에 ID + 1이 되어 다른 글감을 조회하도록하였습니다. 기존 ID는 static 변수로 선언하여 전역에서 관리할 수 있게 했습니다.
3. 만일 findById에서 결과가 나오지 않을 경우 다시 id를 reset하여 51 -> 1으로 바꿔주고, 리턴하는 방식으로 구현했습니다!
```java
    @Scheduled(cron = "0 0 0 * * *")
    private String getRandomContentDaily() {
        return recommendRepository.findById(GROUND_ID + INDEX).orElseGet(() -> {
            resetGroundId();
            return recommendRepository.findById(GROUND_ID + INDEX).orElseThrow(
                    () -> new NotFoundException(ErrorMessage.RECCOMEND_NOT_FOUND)
            );
        }).getContent();
    }
```
## To Reviewers 📢
- 수정사항있으면 알려주세요!