### PR TITLE
#86 [feat] 가입 시 모임 가입 및 필명 생성 플로우 구현

### DIFF
--- a/module-auth/src/main/java/com/mile/external/client/kakao/KakaoSocialService.java
+++ b/module-auth/src/main/java/com/mile/external/client/kakao/KakaoSocialService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class KakaoSocialService implements SocialService {
 
     private static final String AUTH_CODE = "authorization_code";
-    private static final String REDIRECT_URI = "http://localhost:5173/redirect-kakao";
+    private static final String REDIRECT_URI = "https://milewriting.com/kakao/callback";
 
 
     @Value("${kakao.clientId}")

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -29,6 +29,7 @@ public enum ErrorMessage {
     MOIM_TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 모임의 글감이 존재하지 않습니다."),
     TOPIC_POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글감의 글이 존재하지 않습니다."),
     MOIM_POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 모임의 글이 존재하지 않습니다."),
+    RANDOM_VALUE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "랜덤 글 이름을 생성하는데 실패했습니다."),
     /*
     Bad Request
      */

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -4,10 +4,10 @@ import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.ForbiddenException;
 import com.mile.exception.model.NotFoundException;
 import com.mile.moim.domain.Moim;
+import com.mile.moim.repository.MoimRepository;
 import com.mile.moim.service.dto.CategoryListResponse;
 import com.mile.moim.service.dto.ContentListResponse;
 import com.mile.moim.service.dto.MoimAuthenticateResponse;
-import com.mile.moim.repository.MoimRepository;
 import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimInfoResponse;
 import com.mile.moim.service.dto.MoimTopicResponse;
@@ -15,12 +15,12 @@ import com.mile.post.service.PostCuriousService;
 import com.mile.topic.service.TopicService;
 import com.mile.utils.DateUtil;
 import com.mile.writerName.domain.WriterName;
-import java.util.List;
-
 import com.mile.writerName.service.WriterNameService;
 import com.mile.writerName.service.dto.PopularWriterListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +41,7 @@ public class MoimService {
         return ContentListResponse.of(topicService.getContentsFromMoim(moimId));
     }
 
+
     public void authenticateUserOfMoim(
             final Long moimId,
             final Long userId
@@ -57,7 +58,7 @@ public class MoimService {
         return MoimAuthenticateResponse.of(writerNameService.isUserInMoim(moimId, userId));
     }
 
-    private Moim findById(
+    public Moim findById(
             final Long moimId
     ) {
         return moimRepository.findById(moimId).orElseThrow(
@@ -104,10 +105,10 @@ public class MoimService {
     public MoimCuriousPostListResponse getMostCuriousPostFromMoim(final Long moimId) {
         return postCuriousService.getMostCuriousPostByMoim(findById(moimId));
     }
+
     public CategoryListResponse getCategoryList(
             final Long moimId
     ) {
         return CategoryListResponse.of(topicService.getKeywordsFromMoim(moimId));
     }
-
 }

--- a/module-domain/src/main/java/com/mile/user/service/UserService.java
+++ b/module-domain/src/main/java/com/mile/user/service/UserService.java
@@ -54,7 +54,9 @@ public class UserService {
                 userResponse.email(),
                 userResponse.socialType()
         );
-        return userRepository.save(user).getId();
+        userRepository.saveAndFlush(user);
+        createWriterNameOfUser(user);
+        return user.getId();
     }
 
     private void createWriterNameOfUser(

--- a/module-domain/src/main/java/com/mile/user/service/UserService.java
+++ b/module-domain/src/main/java/com/mile/user/service/UserService.java
@@ -9,9 +9,11 @@ import com.mile.external.client.dto.UserLoginRequest;
 import com.mile.external.client.kakao.KakaoSocialService;
 import com.mile.external.client.service.dto.UserInfoResponse;
 import com.mile.jwt.JwtTokenProvider;
+import com.mile.moim.service.MoimService;
 import com.mile.user.domain.User;
 import com.mile.user.repository.UserRepository;
 import com.mile.user.service.dto.LoginSuccessResponse;
+import com.mile.writerName.service.WriterNameService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +24,10 @@ public class UserService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final KakaoSocialService kakaoSocialService;
+    private final MoimService moimService;
+    private final WriterNameService writerNameService;
+
+    private static final Long STATIC_MOIM_ID = 1L;
 
     public LoginSuccessResponse create(
             final String authorizationCode,
@@ -49,6 +55,12 @@ public class UserService {
                 userResponse.socialType()
         );
         return userRepository.save(user).getId();
+    }
+
+    private void createWriterNameOfUser(
+            final User user
+    ) {
+        writerNameService.createWriterNameInMile(user, moimService.findById(STATIC_MOIM_ID));
     }
 
     public User getBySocialId(

--- a/module-domain/src/main/java/com/mile/writerName/domain/RandomWriterNamePrefix.java
+++ b/module-domain/src/main/java/com/mile/writerName/domain/RandomWriterNamePrefix.java
@@ -1,0 +1,18 @@
+package com.mile.writerName.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class RandomWriterNamePrefix {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String prefix;
+}

--- a/module-domain/src/main/java/com/mile/writerName/domain/RandomWriterNameSuffix.java
+++ b/module-domain/src/main/java/com/mile/writerName/domain/RandomWriterNameSuffix.java
@@ -1,0 +1,18 @@
+package com.mile.writerName.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class RandomWriterNameSuffix {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String suffix;
+}

--- a/module-domain/src/main/java/com/mile/writerName/domain/WriterName.java
+++ b/module-domain/src/main/java/com/mile/writerName/domain/WriterName.java
@@ -7,10 +7,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class WriterName {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,5 +36,27 @@ public class WriterName {
 
     public void decreaseTotalCuriousCount() {
         totalCuriousCount--;
+    }
+
+    @Builder
+    private WriterName(
+            final Moim moim,
+            final String name,
+            final User user
+    ) {
+        this.moim = moim;
+        this.name = name;
+        this.writer = user;
+    }
+
+    public static WriterName of(
+            final Moim moim,
+            final String name,
+            final User user
+    ) {
+        return WriterName.builder()
+                .moim(moim)
+                .name(name)
+                .user(user).build();
     }
 }

--- a/module-domain/src/main/java/com/mile/writerName/repository/RandomWriterNamePrefixRepository.java
+++ b/module-domain/src/main/java/com/mile/writerName/repository/RandomWriterNamePrefixRepository.java
@@ -1,0 +1,7 @@
+package com.mile.writerName.repository;
+
+import com.mile.writerName.domain.RandomWriterNamePrefix;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RandomWriterNamePrefixRepository extends JpaRepository<RandomWriterNamePrefix, Long> {
+}

--- a/module-domain/src/main/java/com/mile/writerName/repository/RandomWriterNameSuffixRepository.java
+++ b/module-domain/src/main/java/com/mile/writerName/repository/RandomWriterNameSuffixRepository.java
@@ -1,0 +1,7 @@
+package com.mile.writerName.repository;
+
+import com.mile.writerName.domain.RandomWriterNameSuffix;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RandomWriterNameSuffixRepository extends JpaRepository<RandomWriterNameSuffix, Long> {
+}

--- a/module-domain/src/main/java/com/mile/writerName/service/RandomWriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writerName/service/RandomWriterNameService.java
@@ -1,0 +1,31 @@
+package com.mile.writerName.service;
+
+
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.NotFoundException;
+import com.mile.writerName.repository.RandomWriterNamePrefixRepository;
+import com.mile.writerName.repository.RandomWriterNameSuffixRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class RandomWriterNameService {
+    private final RandomWriterNameSuffixRepository suffixRepository;
+    private final RandomWriterNamePrefixRepository prefixRepository;
+
+    private static final int PREFIX_SEED = 115;
+    private static final int SUFFIX_SEED = 192;
+
+    public String generateRandomWriterName() {
+        Random random = new Random();
+        return prefixRepository.findById(Long.valueOf(random.nextInt(PREFIX_SEED) + 1)).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.RANDOM_VALUE_NOT_FOUND)).getPrefix() +
+                suffixRepository.findById(Long.valueOf(random.nextInt(SUFFIX_SEED) + 1)).orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.RANDOM_VALUE_NOT_FOUND)
+                ).getSuffix();
+
+    }
+}

--- a/module-domain/src/main/java/com/mile/writerName/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writerName/service/WriterNameService.java
@@ -2,17 +2,22 @@ package com.mile.writerName.service;
 
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.NotFoundException;
+import com.mile.moim.domain.Moim;
+import com.mile.user.domain.User;
 import com.mile.writerName.domain.WriterName;
 import com.mile.writerName.repository.WriterNameRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
 @RequiredArgsConstructor
 public class WriterNameService {
     private final WriterNameRepository writerNameRepository;
+    private final RandomWriterNameService randomWriterNameService;
 
     public boolean isUserInMoim(
             final Long moimId,
@@ -74,5 +79,12 @@ public class WriterNameService {
 
     public List<WriterName> findTop2ByCuriousCount(final Long moimid) {
         return writerNameRepository.findTop2ByMoimIdOrderByTotalCuriousCountDesc(moimid);
+    }
+
+    @Transactional
+    public void createWriterNameInMile(final User user, final Moim moim) {
+        writerNameRepository.save(
+                WriterName.of(moim, randomWriterNameService.generateRandomWriterName(), user)
+        );
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #86 

## Key Changes 🔑
1. save만 진행시 아직 db에 반영되지 않은 후에 연관관계를 설정하는 것이기 때문에 saveAndFlush 한 후 연관관계를 설정했습니다.
2. RandomName과 관련된 엔티티를 만들고 그 엔티티에서 접두사 접미사를 random value id 값으로 받아오며 새로운 닉네임을 만들어주었습니다.
3. 카카오 로그인 배포용 redirec uri로 변경했습니다!

## To Reviewers 📢
-
