### PR TITLE
#88 [feat] html 태그 파싱 및 길이 제한 수정

### DIFF
--- a/module-domain/build.gradle
+++ b/module-domain/build.gradle
@@ -6,6 +6,9 @@ dependencies {
     implementation project(':module-common')
     implementation project(':module-external')
 
+    //Jsoup
+    implementation 'org.jsoup:jsoup:1.14.3'
+
     //Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 

--- a/module-domain/src/main/java/com/mile/moim/service/dto/MoimMostCuriousPostResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/MoimMostCuriousPostResponse.java
@@ -1,5 +1,8 @@
 package com.mile.moim.service.dto;
 
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Whitelist;
+
 public record MoimMostCuriousPostResponse(
         Long postId,
         String imageUrl,
@@ -7,6 +10,9 @@ public record MoimMostCuriousPostResponse(
         String title,
         String content
 ) {
+    private static final int SUBSTRING_START = 0;
+    private static final int SUBSTRING_END = 200;
+
     public static MoimMostCuriousPostResponse of(
             Long postId,
             String imageUrl,
@@ -14,6 +20,12 @@ public record MoimMostCuriousPostResponse(
             String title,
             String content
     ) {
-        return new MoimMostCuriousPostResponse(postId, imageUrl, topic, title, content);
+        return new MoimMostCuriousPostResponse(postId, imageUrl, topic, title, getSubStringOfCleanContent(content));
+    }
+
+    private static String getSubStringOfCleanContent(
+            String content
+    ) {
+        return Jsoup.clean(content, Whitelist.none()).substring(SUBSTRING_START, SUBSTRING_END);
     }
 }

--- a/module-domain/src/main/java/com/mile/post/service/dto/PostListResponse.java
+++ b/module-domain/src/main/java/com/mile/post/service/dto/PostListResponse.java
@@ -2,6 +2,8 @@ package com.mile.post.service.dto;
 
 import com.mile.post.domain.Post;
 import com.mile.utils.DateUtil;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Whitelist;
 
 public record PostListResponse(
         Long postId,
@@ -13,8 +15,7 @@ public record PostListResponse(
         String imageUrl
 ) {
     private static final int SUBSTRING_START = 0;
-    private static final int SUBSTRING_END_WITH_IMAGE = 104;
-    private static final int SUBSTRING_END_WITHOUT_IMAGE = 166;
+    private static final int SUBSTRING_END = 200;
 
     public static PostListResponse of(final Post post) {
         return new PostListResponse(post.getId(), post.getTitle(), getSubString(post),
@@ -25,10 +26,6 @@ public record PostListResponse(
     }
 
     private static String getSubString(final Post post) {
-        if (post.getImageUrl().isEmpty()) {
-            return post.getContent().substring(SUBSTRING_START, SUBSTRING_END_WITHOUT_IMAGE);
-        } else {
-            return post.getContent().substring(SUBSTRING_START, SUBSTRING_END_WITH_IMAGE);
-        }
+        return Jsoup.clean(post.getContent(), Whitelist.none()).substring(SUBSTRING_START, SUBSTRING_END);
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #88 

## Key Changes 🔑
1. DTO 내부에서 전체 content를 받아온 후 html 파싱을 진행한 뒤 길이를 200자(웹-서 회의 후 결정)로 substring을 추출했습니다.

## To Reviewers 📢
-
