### PR TITLE
#90 [feat] 임시 저장 글 존재 여부 API 구현

### DIFF
--- a/module-api/src/main/java/com/mile/controller/moim/MoimController.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimController.java
@@ -9,6 +9,7 @@ import com.mile.moim.service.dto.MoimAuthenticateResponse;
 import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimInfoResponse;
 import com.mile.moim.service.dto.MoimTopicResponse;
+import com.mile.moim.service.dto.TemporaryPostExistResponse;
 import com.mile.writerName.service.dto.PopularWriterListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -77,10 +78,20 @@ public class MoimController implements MoimControllerSwagger {
         return SuccessResponse.of(SuccessMessage.CATEGORY_LIST_SEARCH_SUCCESS, moimService.getCategoryList(moimId));
     }
 
+    @Override
     @GetMapping("/{moimId}/mostCuriousPost")
     public SuccessResponse<MoimCuriousPostListResponse> getMostCuriousPostByMoim(
             @PathVariable final Long moimId
     ) {
         return SuccessResponse.of(SuccessMessage.MOIM_TOP_2_POST_GET_SUCCESS, moimService.getMostCuriousPostFromMoim(moimId));
+    }
+
+    @Override
+    @GetMapping("/{moimId}/temporary")
+    public SuccessResponse<TemporaryPostExistResponse> getTemporaryPost(
+            @PathVariable final Long moimId,
+            final Principal principal
+    ) {
+        return SuccessResponse.of(SuccessMessage.IS_TEMPORARY_POST_EXIST_GET_SUCCESS, moimService.getTemporaryPost(moimId, Long.valueOf(principal.getName())));
     }
 }

--- a/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
@@ -7,6 +7,7 @@ import com.mile.moim.service.dto.ContentListResponse;
 import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimInfoResponse;
 import com.mile.moim.service.dto.MoimTopicResponse;
+import com.mile.moim.service.dto.TemporaryPostExistResponse;
 import com.mile.writerName.service.dto.PopularWriterListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -120,5 +121,21 @@ public interface MoimControllerSwagger {
     )
     SuccessResponse<CategoryListResponse> getCategoryList(
             @PathVariable final Long moimId
+    );
+
+    @Operation(summary = "임시 저장 글 존재 여부 조회")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "임시저장 글 존재 여부 조회가 완료되었습니다."),
+                    @ApiResponse(responseCode = "404", description = "1. 해당 글모임이 존재하지 않습니다.\n" +
+                            "2. 해당 작가는 존재하지 않습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    SuccessResponse<TemporaryPostExistResponse> getTemporaryPost(
+            @PathVariable final Long moimId,
+            final Principal principal
     );
 }

--- a/module-auth/src/main/java/com/mile/external/client/kakao/KakaoSocialService.java
+++ b/module-auth/src/main/java/com/mile/external/client/kakao/KakaoSocialService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class KakaoSocialService implements SocialService {
 
     private static final String AUTH_CODE = "authorization_code";
-    private static final String REDIRECT_URI = "https://milewriting.com/kakao/callback";
+    private static final String REDIRECT_URI = "http://localhost:5173/redirect-kakao";
 
 
     @Value("${kakao.clientId}")

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -30,6 +30,7 @@ public enum SuccessMessage {
     MOIM_TOP_2_POST_GET_SUCCESS(HttpStatus.OK.value(), "궁금해요 상위 2개의 글이 조회 완료되었습니다."),
     POST_GET_SUCCESS(HttpStatus.OK.value(), "글 조회가 완료되었습니다."),
     MOIM_POST_GET_SUCCESS(HttpStatus.OK.value(), "카테고리별 글 리스트 조회가 완료되었습니다."),
+    IS_TEMPORARY_POST_EXIST_GET_SUCCESS(HttpStatus.OK.value(), "임시저장 글 존재 여부 조회가 완료되었습니다."),
     /*
     201 CREATED
      */

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -11,10 +11,14 @@ import com.mile.moim.repository.MoimRepository;
 import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimInfoResponse;
 import com.mile.moim.service.dto.MoimTopicResponse;
+import com.mile.moim.service.dto.TemporaryPostExistResponse;
 import com.mile.post.service.PostCuriousService;
+import com.mile.post.service.PostService;
+import com.mile.post.service.PostTemporaryService;
 import com.mile.topic.service.TopicService;
 import com.mile.utils.DateUtil;
 import com.mile.writerName.domain.WriterName;
+
 import java.util.List;
 
 import com.mile.writerName.service.WriterNameService;
@@ -30,6 +34,7 @@ public class MoimService {
     private final TopicService topicService;
     private final MoimRepository moimRepository;
     private final PostCuriousService postCuriousService;
+    private final PostTemporaryService postTemporaryService;
 
     private static final int NUMBER_OF_MOST_CURIOUS_WRITERS = 2;
 
@@ -104,10 +109,18 @@ public class MoimService {
     public MoimCuriousPostListResponse getMostCuriousPostFromMoim(final Long moimId) {
         return postCuriousService.getMostCuriousPostByMoim(findById(moimId));
     }
+
     public CategoryListResponse getCategoryList(
             final Long moimId
     ) {
         return CategoryListResponse.of(topicService.getKeywordsFromMoim(moimId));
     }
 
+    public TemporaryPostExistResponse getTemporaryPost(
+            final Long moimId,
+            final Long userId
+    ) {
+        Long postId = postTemporaryService.getTemporaryPostExist(findById(moimId), writerNameService.findByWriterId(userId));
+        return TemporaryPostExistResponse.of(!postId.equals(0L), postId);
+    }
 }

--- a/module-domain/src/main/java/com/mile/moim/service/dto/TemporaryPostExistResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/TemporaryPostExistResponse.java
@@ -1,0 +1,13 @@
+package com.mile.moim.service.dto;
+
+public record TemporaryPostExistResponse(
+        boolean isTemporaryPostExist,
+        Long postId
+) {
+    public static TemporaryPostExistResponse of(
+            final boolean isTemporaryPostExist,
+            final Long postId
+    ) {
+        return new TemporaryPostExistResponse(isTemporaryPostExist, postId);
+    }
+}

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepository.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepository.java
@@ -10,4 +10,5 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     boolean existsPostByIdAndWriterNameId(final Long postId, final Long userId);
 
     List<Post> findByTopic(final Topic topic);
+
 }

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepositoryCustom.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepositoryCustom.java
@@ -2,9 +2,12 @@ package com.mile.post.repository;
 
 import com.mile.moim.domain.Moim;
 import com.mile.post.domain.Post;
+import com.mile.writerName.domain.WriterName;
 
 import java.util.List;
 
 public interface PostRepositoryCustom {
     List<Post> findTop2ByMoimOrderByCuriousCountDesc(final Moim requestMoim);
+
+    List<Post> findByMoimAndWriterNameWhereIsTemporary(final Moim moim, final WriterName writerName);
 }

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepositoryImpl.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.mile.post.repository;
 
 import com.mile.moim.domain.Moim;
 import com.mile.post.domain.Post;
+import com.mile.writerName.domain.WriterName;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -10,6 +11,7 @@ import java.util.stream.Collectors;
 
 import static com.mile.moim.domain.QMoim.moim;
 import static com.mile.post.domain.QPost.post;
+import static com.mile.writerName.domain.QWriterName.writerName;
 
 @RequiredArgsConstructor
 public class PostRepositoryImpl implements PostRepositoryCustom {
@@ -24,4 +26,13 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .stream().limit(2).collect(Collectors.toList());
     }
 
+    public List<Post> findByMoimAndWriterNameWhereIsTemporary(final Moim requestMoim, final WriterName requestWriterName) {
+        return jpaQueryFactory.selectFrom(post)
+                .join(moim)
+                .on(post.topic.moim.eq(requestMoim))
+                .join(writerName)
+                .on(post.writerName.eq(requestWriterName))
+                .where(post.isTemporary.eq(true))
+                .stream().toList();
+    }
 }

--- a/module-domain/src/main/java/com/mile/post/service/PostTemporaryService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostTemporaryService.java
@@ -1,0 +1,34 @@
+package com.mile.post.service;
+
+import com.mile.moim.domain.Moim;
+import com.mile.post.domain.Post;
+import com.mile.post.repository.PostRepository;
+import com.mile.writerName.domain.WriterName;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostTemporaryService {
+    private final PostRepository postRepository;
+
+    public Long getTemporaryPostExist(
+            final Moim moim,
+            final WriterName writerName
+    ) {
+        List<Post> postList = postRepository.findByMoimAndWriterNameWhereIsTemporary(moim, writerName);
+        if(isPostListEmpty(postList)) {
+            return 0L;
+        }
+        return postList.stream().sorted(Comparator.comparing(Post::getCreatedAt).reversed()).toList().get(0).getId();
+    }
+
+    private boolean isPostListEmpty(
+            final List<Post> postList
+    ) {
+        return postList.isEmpty();
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #90 

## Key Changes 🔑
1. PostService 임시저장글 관련 로직은 분리했습니다!
2. QueryDsl 사용했습니다! 
3. 카카오 소셜 로그인 플로우 확인 완료 -> redirect uri 최종 수정

## To Reviewers 📢
-
