### PR TITLE
#84 GET - 베스트 활동 모임 및 모임별 글 조회

### DIFF
--- a/module-api/src/main/java/com/mile/controller/moim/MoimController.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimController.java
@@ -3,6 +3,7 @@ package com.mile.controller.moim;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
 import com.mile.moim.service.MoimService;
+import com.mile.moim.service.dto.BestMoimListResponse;
 import com.mile.moim.service.dto.CategoryListResponse;
 import com.mile.moim.service.dto.ContentListResponse;
 import com.mile.moim.service.dto.MoimAuthenticateResponse;
@@ -10,13 +11,12 @@ import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimInfoResponse;
 import com.mile.moim.service.dto.MoimTopicResponse;
 import com.mile.writerName.service.dto.PopularWriterListResponse;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor
@@ -83,4 +83,10 @@ public class MoimController implements MoimControllerSwagger {
     ) {
         return SuccessResponse.of(SuccessMessage.MOIM_TOP_2_POST_GET_SUCCESS, moimService.getMostCuriousPostFromMoim(moimId));
     }
+
+    @GetMapping("/best")
+    public SuccessResponse<BestMoimListResponse> getBestMoimAndPostList() {
+        return SuccessResponse.of(SuccessMessage.BEST_MOIM_POSTS_GET_SUCCESS, moimService.getBestMoimAndPostList());
+    }
+
 }

--- a/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
@@ -2,6 +2,7 @@ package com.mile.controller.moim;
 
 import com.mile.dto.ErrorResponse;
 import com.mile.dto.SuccessResponse;
+import com.mile.moim.service.dto.BestMoimListResponse;
 import com.mile.moim.service.dto.CategoryListResponse;
 import com.mile.moim.service.dto.ContentListResponse;
 import com.mile.moim.service.dto.MoimCuriousPostListResponse;
@@ -121,4 +122,14 @@ public interface MoimControllerSwagger {
     SuccessResponse<CategoryListResponse> getCategoryList(
             @PathVariable final Long moimId
     );
+
+    @Operation(summary = "베스트 활동 모임 및 글 리스트 조회")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "베스트 활동 모임과 글 리스트 조회가 완료되었습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    SuccessResponse<BestMoimListResponse> getBestMoimAndPostList();
 }

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -30,6 +30,7 @@ public enum SuccessMessage {
     MOIM_TOP_2_POST_GET_SUCCESS(HttpStatus.OK.value(), "궁금해요 상위 2개의 글이 조회 완료되었습니다."),
     POST_GET_SUCCESS(HttpStatus.OK.value(), "글 조회가 완료되었습니다."),
     MOIM_POST_GET_SUCCESS(HttpStatus.OK.value(), "카테고리별 글 리스트 조회가 완료되었습니다."),
+    BEST_MOIM_POSTS_GET_SUCCESS(HttpStatus.OK.value(), "베스트 활동 모임과 글 조회가 완료되었습니다."),
     /*
     201 CREATED
      */

--- a/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
+++ b/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
@@ -2,9 +2,12 @@ package com.mile.moim.repository;
 
 import com.mile.moim.domain.Moim;
 import com.mile.post.domain.Post;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface MoimRepository extends JpaRepository<Moim, Long> {
+public interface MoimRepository extends JpaRepository<Moim, Long>, MoimRepositoryCustom {
     List<Post> getPostsById(final Long id);
 }

--- a/module-domain/src/main/java/com/mile/moim/repository/MoimRepositoryCustom.java
+++ b/module-domain/src/main/java/com/mile/moim/repository/MoimRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.mile.moim.repository;
+
+import com.mile.moim.domain.Moim;
+import java.util.List;
+
+public interface MoimRepositoryCustom {
+
+    List<Moim> findTop3MoimsByPostCount();
+}

--- a/module-domain/src/main/java/com/mile/moim/repository/MoimRepositoryCustomImpl.java
+++ b/module-domain/src/main/java/com/mile/moim/repository/MoimRepositoryCustomImpl.java
@@ -1,8 +1,9 @@
 package com.mile.moim.repository;
 
+import static com.mile.moim.domain.QMoim.moim;
+import static com.mile.post.domain.QPost.post;
+
 import com.mile.moim.domain.Moim;
-import com.mile.moim.domain.QMoim;
-import com.mile.post.domain.QPost;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,8 +14,6 @@ public class MoimRepositoryCustomImpl implements MoimRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     public List<Moim> findTop3MoimsByPostCount() {
-        QMoim moim = QMoim.moim;
-        QPost post = QPost.post;
 
         LocalDateTime oneWeekAgo = LocalDateTime.now().minusWeeks(1);
 

--- a/module-domain/src/main/java/com/mile/moim/repository/MoimRepositoryCustomImpl.java
+++ b/module-domain/src/main/java/com/mile/moim/repository/MoimRepositoryCustomImpl.java
@@ -1,0 +1,33 @@
+package com.mile.moim.repository;
+
+import com.mile.moim.domain.Moim;
+import com.mile.moim.domain.QMoim;
+import com.mile.post.domain.QPost;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MoimRepositoryCustomImpl implements MoimRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    public List<Moim> findTop3MoimsByPostCount() {
+        QMoim moim = QMoim.moim;
+        QPost post = QPost.post;
+
+        LocalDateTime oneWeekAgo = LocalDateTime.now().minusWeeks(1);
+
+        List<Moim> result = queryFactory
+                .select(moim)
+                .from(moim)
+                .leftJoin(post).on(moim.eq(post.topic.moim))
+                .where(post.createdAt.after(oneWeekAgo))
+                .groupBy(moim)
+                .orderBy(post.id.count().desc())
+                .limit(3)
+                .fetch();
+
+        return result;
+    }
+}

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -16,6 +16,7 @@ import com.mile.moim.service.dto.TemporaryPostExistResponse;
 import com.mile.post.domain.Post;
 import com.mile.post.service.PostAuthenticateService;
 import com.mile.post.service.PostCuriousService;
+import com.mile.post.service.PostGetService;
 import com.mile.post.service.PostService;
 import com.mile.post.service.PostTemporaryService;
 import com.mile.topic.service.TopicService;
@@ -38,9 +39,9 @@ public class MoimService {
     private final TopicService topicService;
     private final MoimRepository moimRepository;
     private final PostCuriousService postCuriousService;
-    private final PostService postService;
     private final PostAuthenticateService postAuthenticateService;
     private final PostTemporaryService postTemporaryService;
+    private final PostGetService postGetService;
 
     private static final int NUMBER_OF_MOST_CURIOUS_WRITERS = 2;
 
@@ -133,7 +134,7 @@ public class MoimService {
         Map<Moim, List<Post>> BestMoimAndPost = new HashMap<>();
         List<Moim> bestMoimsByPostNumber = getBestMoimByPostNumber();
         for (Moim moim : bestMoimsByPostNumber) {
-            List<Post> latestPosts = postService.getLatestPostsByMoim(moim);
+            List<Post> latestPosts = postGetService.getLatestPostsByMoim(moim);
             BestMoimAndPost.put(moim, latestPosts);
         }
         return BestMoimListResponse.of(BestMoimAndPost);

--- a/module-domain/src/main/java/com/mile/moim/service/dto/BestMoimInfoResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/BestMoimInfoResponse.java
@@ -1,0 +1,18 @@
+package com.mile.moim.service.dto;
+
+import com.mile.moim.domain.Moim;
+import com.mile.post.domain.Post;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record BestMoimInfoResponse(Long moimId, String moimName, List<BestMoimPostResponse> moimPosts) {
+    public static BestMoimInfoResponse of(Moim moim, final List<Post> posts) {
+        return new BestMoimInfoResponse(
+                moim.getId(),
+                moim.getName(),
+                posts.stream()
+                    .map(BestMoimPostResponse::of)
+                    .collect(Collectors.toList())
+        );
+    }
+}

--- a/module-domain/src/main/java/com/mile/moim/service/dto/BestMoimListResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/BestMoimListResponse.java
@@ -1,0 +1,18 @@
+package com.mile.moim.service.dto;
+
+import com.mile.moim.domain.Moim;
+import com.mile.post.domain.Post;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public record BestMoimListResponse(List<BestMoimInfoResponse> moim) {
+    public static BestMoimListResponse of(Map<Moim, List<Post>> BestMoimAndPost) {
+        List<BestMoimInfoResponse> bestMoims = new ArrayList<>();
+        for (Moim moim : BestMoimAndPost.keySet()) {
+            bestMoims.add(BestMoimInfoResponse.of(moim, BestMoimAndPost.get(moim)));
+        }
+        return new BestMoimListResponse(bestMoims);
+
+    }
+}

--- a/module-domain/src/main/java/com/mile/moim/service/dto/BestMoimPostResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/BestMoimPostResponse.java
@@ -1,0 +1,14 @@
+package com.mile.moim.service.dto;
+
+import com.mile.post.domain.Post;
+
+public record BestMoimPostResponse(String topicName, String imageUrl, String postTitle, String postContent) {
+    public static BestMoimPostResponse of(Post post) {
+        return new BestMoimPostResponse(
+                post.getTopic().getContent(),
+                post.getImageUrl(),
+                post.getTitle(),
+                post.getContent()
+        );
+    }
+}

--- a/module-domain/src/main/java/com/mile/moim/service/dto/BestMoimPostResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/BestMoimPostResponse.java
@@ -1,14 +1,32 @@
 package com.mile.moim.service.dto;
 
 import com.mile.post.domain.Post;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Whitelist;
 
 public record BestMoimPostResponse(String topicName, String imageUrl, String postTitle, String postContent) {
+    private static final int SUBSTRING_START = 0;
+    private static final int SUBSTRING_END = 200;
+
     public static BestMoimPostResponse of(Post post) {
+
         return new BestMoimPostResponse(
                 post.getTopic().getContent(),
                 post.getImageUrl(),
                 post.getTitle(),
-                post.getContent()
+                getSubStringOfCleanContent(post.getContent())
         );
     }
+
+    private static String getSubStringOfCleanContent(
+            String content
+    ) {
+        return Jsoup.clean(content, Whitelist.none()).substring(SUBSTRING_START, SUBSTRING_END);
+    }
 }
+
+/*
+    private static String getSubString(final Post post) {
+        return Jsoup.clean(post.getContent(), Whitelist.none()).substring(SUBSTRING_START, SUBSTRING_END);
+ */
+

--- a/module-domain/src/main/java/com/mile/moim/service/dto/BestMoimPostResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/BestMoimPostResponse.java
@@ -21,12 +21,11 @@ public record BestMoimPostResponse(String topicName, String imageUrl, String pos
     private static String getSubStringOfCleanContent(
             String content
     ) {
-        return Jsoup.clean(content, Whitelist.none()).substring(SUBSTRING_START, SUBSTRING_END);
+        String cleanContent = Jsoup.clean(content, Whitelist.none());
+        if (cleanContent.length() >= SUBSTRING_END) {
+            return cleanContent.substring(SUBSTRING_START, SUBSTRING_END);
+        } else {
+            return cleanContent;
+        }
     }
 }
-
-/*
-    private static String getSubString(final Post post) {
-        return Jsoup.clean(post.getContent(), Whitelist.none()).substring(SUBSTRING_START, SUBSTRING_END);
- */
-

--- a/module-domain/src/main/java/com/mile/moim/service/dto/MoimMostCuriousPostResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/MoimMostCuriousPostResponse.java
@@ -26,6 +26,11 @@ public record MoimMostCuriousPostResponse(
     private static String getSubStringOfCleanContent(
             String content
     ) {
-        return Jsoup.clean(content, Whitelist.none()).substring(SUBSTRING_START, SUBSTRING_END);
+        String cleanContent = Jsoup.clean(content, Whitelist.none());
+        if (cleanContent.length() >= SUBSTRING_END) {
+            return cleanContent.substring(SUBSTRING_START, SUBSTRING_END);
+        } else {
+            return cleanContent;
+        }
     }
 }

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepository.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepository.java
@@ -2,12 +2,10 @@ package com.mile.post.repository;
 
 import com.mile.post.domain.Post;
 import com.mile.topic.domain.Topic;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
     boolean existsPostByIdAndWriterNameId(final Long postId, final Long userId);
-
     List<Post> findByTopic(final Topic topic);
 }

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepositoryCustom.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepositoryCustom.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface PostRepositoryCustom {
     List<Post> findTop2ByMoimOrderByCuriousCountDesc(final Moim requestMoim);
+    List<Post> findLatest4PostsByMoim(Moim moim);
 }
+

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepositoryImpl.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepositoryImpl.java
@@ -27,7 +27,6 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     public List<Post> findLatest4PostsByMoim(Moim moim) {
-        QPost post = QPost.post;
 
         List<Post> result = jpaQueryFactory
                 .select(post)

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepositoryImpl.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepositoryImpl.java
@@ -1,15 +1,15 @@
 package com.mile.post.repository;
 
-import com.mile.moim.domain.Moim;
-import com.mile.post.domain.Post;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
 import static com.mile.moim.domain.QMoim.moim;
 import static com.mile.post.domain.QPost.post;
+
+import com.mile.moim.domain.Moim;
+import com.mile.post.domain.Post;
+import com.mile.post.domain.QPost;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class PostRepositoryImpl implements PostRepositoryCustom {
@@ -22,6 +22,20 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .on(post.topic.moim.eq(requestMoim))
                 .orderBy(post.curiousCount.desc())
                 .stream().limit(2).collect(Collectors.toList());
+    }
+
+    public List<Post> findLatest4PostsByMoim(Moim moim) {
+        QPost post = QPost.post;
+
+        List<Post> result = jpaQueryFactory
+                .select(post)
+                .from(post)
+                .where(post.topic.moim.eq(moim))
+                .orderBy(post.createdAt.desc())
+                .limit(4)
+                .fetch();
+
+        return result;
     }
 
 }

--- a/module-domain/src/main/java/com/mile/post/service/PostAuthenticateService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostAuthenticateService.java
@@ -3,10 +3,8 @@ package com.mile.post.service;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.ForbiddenException;
 import com.mile.exception.model.NotFoundException;
-import com.mile.moim.service.MoimService;
 import com.mile.post.domain.Post;
 import com.mile.post.repository.PostRepository;
-import com.mile.writerName.domain.WriterName;
 import com.mile.writerName.service.WriterNameService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,7 +12,6 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class PostAuthenticateService {
-    private final MoimService moimService;
     private final PostRepository postRepository;
     private final WriterNameService writerNameService;
 
@@ -31,7 +28,16 @@ public class PostAuthenticateService {
             final Long userId
     ) {
         Long moimId = post.getTopic().getMoim().getId();
-        moimService.authenticateUserOfMoim(moimId, userId);
+        authenticateUserOfMoim(moimId, userId);
+    }
+
+    public void authenticateUserOfMoim(
+            final Long moimId,
+            final Long userId
+    ) {
+        if (!writerNameService.isUserInMoim(moimId, userId)) {
+            throw new ForbiddenException(ErrorMessage.USER_AUTHENTICATE_ERROR);
+        }
     }
 
     private Post findById(

--- a/module-domain/src/main/java/com/mile/post/service/PostGetService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostGetService.java
@@ -2,6 +2,7 @@ package com.mile.post.service;
 
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.NotFoundException;
+import com.mile.moim.domain.Moim;
 import com.mile.post.domain.Post;
 import com.mile.post.repository.PostRepository;
 import com.mile.topic.domain.Topic;
@@ -39,5 +40,9 @@ public class PostGetService {
         if (postList.isEmpty()) {
             throw new NotFoundException(ErrorMessage.MOIM_TOPIC_NOT_FOUND);
         }
+    }
+
+    public List<Post> getLatestPostsByMoim(Moim moim) {
+        return postRepository.findLatest4PostsByMoim(moim);
     }
 }

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -4,7 +4,6 @@ import com.mile.aws.utils.S3Service;
 import com.mile.comment.service.CommentService;
 import com.mile.curious.service.CuriousService;
 import com.mile.curious.service.dto.CuriousInfoResponse;
-import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.BadRequestException;
 import com.mile.exception.model.NotFoundException;
@@ -23,12 +22,10 @@ import com.mile.topic.domain.Topic;
 import com.mile.topic.service.TopicService;
 import com.mile.user.service.UserService;
 import com.mile.writerName.service.WriterNameService;
-import jakarta.validation.Valid;
-import java.security.Principal;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestBody;
 
 
 @Service
@@ -233,6 +230,11 @@ public class PostService {
 
     private boolean checkContainPhoto(String imageUrl) {
         return imageUrl != null && !imageUrl.isEmpty();
+    }
+
+
+    public List<Post> getLatestPostsByMoim(Moim moim) {
+        return postRepository.findLatest4PostsByMoim(moim);
     }
 
 }

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -237,10 +237,6 @@ public class PostService {
     }
 
 
-    public List<Post> getLatestPostsByMoim(Moim moim) {
-        return postRepository.findLatest4PostsByMoim(moim);
-    }
-
     @Transactional
     public WriterNameResponse putFixedPost(final Long userId, final PostPutRequest request, final Long postId) {
         postAuthenticateService.authenticateWriterWithPost(postId, userId);

--- a/module-domain/src/main/java/com/mile/post/service/dto/PostListResponse.java
+++ b/module-domain/src/main/java/com/mile/post/service/dto/PostListResponse.java
@@ -26,6 +26,11 @@ public record PostListResponse(
     }
 
     private static String getSubString(final Post post) {
-        return Jsoup.clean(post.getContent(), Whitelist.none()).substring(SUBSTRING_START, SUBSTRING_END);
+        String cleanContent = Jsoup.clean(post.getContent(), Whitelist.none());
+        if (cleanContent.length() >= SUBSTRING_END) {
+            return cleanContent.substring(SUBSTRING_START, SUBSTRING_END);
+        } else {
+            return cleanContent;
+        }
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #84 

## Key Changes 🔑
베스트 활동 모임 및 모임별 글 조회를 구현하였습니다!

## To Reviewers 📢
1. query dsl 를 사용하여 글 개수가 많은 모임을 리턴하고, 모임 내 최신순 글을 리턴하였습니다.
2. 순환 참조 해결을 위해 postService에 있던 메소드를 postGetService로 변경하였습니다.
3. Jsoup를 이용하여 도짜미가 구현해준 메서드로 html 태그 제거를 하였는데 content의 길이가 200 미만인 경우에 대해서 에러가 발생해서, 길이를 검사하는 로직을 추가했습니다.