### PR TITLE
#108 [fix] 연관관계 변경 및 쿼리문 재작성

### DIFF
--- a/module-domain/src/main/java/com/mile/moim/domain/Moim.java
+++ b/module-domain/src/main/java/com/mile/moim/domain/Moim.java
@@ -2,6 +2,7 @@ package com.mile.moim.domain;
 
 import com.mile.config.BaseTimeEntity;
 import com.mile.user.domain.User;
+import com.mile.writerName.domain.WriterName;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,7 +17,7 @@ public class Moim extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
-    private User owner;
+    private WriterName owner;
     private String name;
     private String imageUrl;
     private String information;

--- a/module-domain/src/main/java/com/mile/writerName/repository/WriterNameRepositoryImpl.java
+++ b/module-domain/src/main/java/com/mile/writerName/repository/WriterNameRepositoryImpl.java
@@ -15,7 +15,8 @@ public class WriterNameRepositoryImpl implements WriterNameRepositoryCustom {
         return jpaQueryFactory.selectFrom(writerName)
                 .select(writerName.name)
                 .leftJoin(moim)
-                .on(writerName.writer.eq(moim.owner))
+                .on(writerName.moim.id.eq(moimId))
+                .where(writerName.eq(moim.owner))
                 .fetchOne();
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #108 

## Key Changes 🔑
1. 현재 db에서 moim의 owner가 빈 값이었는데 writername과 owner가 같은 것을 join하므로 user의 모든 테이블의 join되었습니다! 그래서 non unique result -> 쿼리문에 한개 이상의 결과가 나오는 예외가 발생했습니다!
2. 모임 정보에서 필명을 가져오는데 writerName과 연관관계가 있는게 맞다고 판단되어 owner를 writername 객체와 연관관계를 정해주었습니다!
3. where문을 작성해서 한개의 결과만 return 하도록 하였습니다!

## To Reviewers 📢
- db도 수정하겠습니다!
