### PR TITLE
#119 [fix] 글 궁금해요 기준 정렬 쿼리문 수정

### DIFF
--- a/module-domain/src/main/java/com/mile/post/repository/PostRepositoryImpl.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.mile.post.repository;
 
 import static com.mile.moim.domain.QMoim.moim;
 import static com.mile.post.domain.QPost.post;
+import static com.mile.topic.domain.QTopic.topic;
 import static com.mile.writerName.domain.QWriterName.writerName;
 
 import com.mile.moim.domain.Moim;
@@ -9,21 +10,29 @@ import com.mile.post.domain.Post;
 import com.mile.post.domain.QPost;
 import com.mile.writerName.domain.WriterName;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import java.util.List;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
+@Slf4j
 public class PostRepositoryImpl implements PostRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
-    // select post from post join moim
+    // select p from post p join moim m on p.topic = m.topic orderby p.curiousCount limit 2
     public List<Post> findTop2ByMoimOrderByCuriousCountDesc(final Moim requestMoim) {
-        return jpaQueryFactory.selectFrom(post)
-                .join(moim)
-                .on(post.topic.moim.eq(requestMoim))
+        return jpaQueryFactory
+                .selectFrom(post)
+                .join(topic).on(post.topic.eq(topic))
+                .join(moim).on(topic.moim.eq(moim))
+                .where(moim.eq(moim))
                 .orderBy(post.curiousCount.desc())
-                .stream().limit(2).collect(Collectors.toList());
+                .limit(2)
+                .fetch();
+
     }
 
     public List<Post> findLatest4PostsByMoim(Moim moim) {


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #119 

## Key Changes 🔑
1. 아래 쿼리문 기준으로 queryDsl로 마이그레이션했습니다!
```java
SELECT post.*
FROM post
JOIN topic t ON t.id = post.topic_id
JOIN moim m ON t.moim_id= m.id
WHERE m.id = :moim_id
ORDER BY post.curious_count DESC
LIMIT 2;
```

## To Reviewers 📢
-
