### PR TITLE
#123 [fix] 글 생성 및 임시저장 후 저장 API 반환 DTO 변경

### DIFF
--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -222,7 +222,7 @@ public class PostService {
                 postCreateRequest.anonymous(),
                 TEMPRORARY_FALSE
         );
-        postRepository.save(post);
+        postRepository.saveAndFlush(post);
         return WriterNameResponse.of(post.getId(), writerName.getName());
     }
 

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -212,7 +212,7 @@ public class PostService {
     ) {
         postAuthenticateService.authenticateWriterOfMoim(userId, postCreateRequest.moimId());
         WriterName writerName = writerNameService.findByMoimAndUser(postCreateRequest.moimId(), userId);
-        postRepository.save(Post.create(
+        Post post = Post.create(
                 topicService.findById(postCreateRequest.topicId()), // Topic
                 writerName, // WriterName
                 postCreateRequest.title(),
@@ -221,8 +221,9 @@ public class PostService {
                 checkContainPhoto(postCreateRequest.imageUrl()),
                 postCreateRequest.anonymous(),
                 TEMPRORARY_FALSE
-        ));
-        return WriterNameResponse.of(writerName.getName());
+        );
+        postRepository.save(post);
+        return WriterNameResponse.of(post.getId(), writerName.getName());
     }
 
     public void createTemporaryPost(
@@ -253,6 +254,6 @@ public class PostService {
         Post post = findById(postId);
         isPostTemporary(post);
         post.updatePost(topicService.findById(request.topicId()), request);
-        return WriterNameResponse.of(post.getWriterName().getName());
+        return WriterNameResponse.of(post.getId(), post.getWriterName().getName());
     }
 }

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -212,7 +212,13 @@ public class PostService {
     ) {
         postAuthenticateService.authenticateWriterOfMoim(userId, postCreateRequest.moimId());
         WriterName writerName = writerNameService.findByMoimAndUser(postCreateRequest.moimId(), userId);
-        Post post = Post.create(
+        Post post = createPost(postCreateRequest, writerName);
+        postRepository.saveAndFlush(post);
+        return WriterNameResponse.of(post.getId(), writerName.getName());
+    }
+
+    private Post createPost(final PostCreateRequest postCreateRequest, final WriterName writerName) {
+        return Post.create(
                 topicService.findById(postCreateRequest.topicId()), // Topic
                 writerName, // WriterName
                 postCreateRequest.title(),
@@ -222,10 +228,7 @@ public class PostService {
                 postCreateRequest.anonymous(),
                 TEMPRORARY_FALSE
         );
-        postRepository.saveAndFlush(post);
-        return WriterNameResponse.of(post.getId(), writerName.getName());
     }
-
     public void createTemporaryPost(
             final Long userId,
             final TemporaryPostCreateRequest temporaryPostCreateRequest

--- a/module-domain/src/main/java/com/mile/writerName/service/dto/WriterNameResponse.java
+++ b/module-domain/src/main/java/com/mile/writerName/service/dto/WriterNameResponse.java
@@ -1,11 +1,13 @@
 package com.mile.writerName.service.dto;
 
 public record WriterNameResponse(
+        Long postId,
         String writerName
 ) {
     public static WriterNameResponse of(
+            final Long postId,
             final String writerName
     ) {
-        return new WriterNameResponse(writerName);
+        return new WriterNameResponse(postId, writerName);
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #123 

## Key Changes 🔑
1. 글 생성 및 임시저장 후 저장 API 반환 DTO에서 postId를 함께 넘겨 주도록 변경하였습니다.
2. 엔터티를 저장하고 즉시 플러시하여 데이터베이스에 변경 사항을 반영 한 후 post의 getId를 할 수 있도록, saveAndFlush를 사용하였습니다.
