### PR TITLE
#132 [feat] principal null exception 해결 및 secure url 로직 분리

### DIFF
--- a/module-api/src/main/java/com/mile/controller/comment/CommentController.java
+++ b/module-api/src/main/java/com/mile/controller/comment/CommentController.java
@@ -1,6 +1,7 @@
 package com.mile.controller.comment;
 
 
+import com.mile.authentication.PrincipalHandler;
 import com.mile.comment.service.CommentService;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
@@ -19,14 +20,14 @@ import java.security.Principal;
 public class CommentController implements CommentControllerSwagger{
 
     private final CommentService commentService;
+    private final PrincipalHandler principalHandler;
 
     @DeleteMapping("/{commentId}")
     public SuccessResponse deleteComment(
             @CommentIdPathVariable final Long commentId,
-            final Principal principal,
             @PathVariable("commentId") final String commentUrl
     ) {
-        commentService.deleteComment(commentId, Long.valueOf(principal.getName()));
+        commentService.deleteComment(commentId, principalHandler.getUserIdFromPrincipal());
         return SuccessResponse.of(SuccessMessage.COMMENT_DELETE_SUCCESS);
     }
 }

--- a/module-api/src/main/java/com/mile/controller/comment/CommentControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/comment/CommentControllerSwagger.java
@@ -29,7 +29,6 @@ public interface CommentControllerSwagger {
     )
     SuccessResponse deleteComment(
             final Long commentId,
-            final Principal principal,
             @PathVariable("commentId") final String commentUrl
     );
 }

--- a/module-api/src/main/java/com/mile/controller/moim/MoimController.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimController.java
@@ -1,5 +1,6 @@
 package com.mile.controller.moim;
 
+import com.mile.authentication.PrincipalHandler;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
 import com.mile.moim.service.MoimService;
@@ -14,9 +15,8 @@ import com.mile.moim.service.dto.TopicListResponse;
 import com.mile.resolver.moim.MoimIdPathVariable;
 import com.mile.writerName.service.dto.PopularWriterListResponse;
 
-import java.security.Principal;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,25 +28,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class MoimController implements MoimControllerSwagger {
 
     private final MoimService moimService;
+    private final PrincipalHandler principalHandler;
 
     @Override
     @GetMapping("/{moimId}")
     public SuccessResponse<ContentListResponse> getTopicsFromMoim(
             @MoimIdPathVariable final Long moimId,
-            final Principal principal,
             @PathVariable("moimId") final String moimUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.TOPIC_SEARCH_SUCCESS, moimService.getContentsFromMoim(moimId, Long.valueOf(principal.getName())));
+        return SuccessResponse.of(SuccessMessage.TOPIC_SEARCH_SUCCESS, moimService.getContentsFromMoim(moimId, principalHandler.getUserIdFromPrincipal()));
     }
 
     @Override
     @GetMapping("/{moimId}/authenticate")
     public SuccessResponse<MoimAuthenticateResponse> getAuthenticationOfMoim(
             @MoimIdPathVariable final Long moimId,
-            final Principal principal,
             @PathVariable("moimId") final String moimUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.MOIM_AUTHENTICATE_SUCCESS, moimService.getAuthenticateUserOfMoim(moimId, Long.valueOf(principal.getName())));
+        return SuccessResponse.of(SuccessMessage.MOIM_AUTHENTICATE_SUCCESS, moimService.getAuthenticateUserOfMoim(moimId, principalHandler.getUserIdFromPrincipal()));
     }
 
     @Override
@@ -105,9 +104,8 @@ public class MoimController implements MoimControllerSwagger {
     @GetMapping("/{moimId}/temporary")
     public SuccessResponse<TemporaryPostExistResponse> getTemporaryPost(
             @MoimIdPathVariable final Long moimId,
-            final Principal principal,
             @PathVariable("moimId") final String moimUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.IS_TEMPORARY_POST_EXIST_GET_SUCCESS, moimService.getTemporaryPost(moimId, Long.valueOf(principal.getName())));
+        return SuccessResponse.of(SuccessMessage.IS_TEMPORARY_POST_EXIST_GET_SUCCESS, moimService.getTemporaryPost(moimId, principalHandler.getUserIdFromPrincipal()));
     }
 }

--- a/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
@@ -38,7 +38,6 @@ public interface MoimControllerSwagger {
     )
     SuccessResponse<ContentListResponse> getTopicsFromMoim(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long moimId,
-            final Principal principal,
             @PathVariable("moimId") final String moimUrl
     );
 
@@ -56,7 +55,6 @@ public interface MoimControllerSwagger {
     )
     SuccessResponse getAuthenticationOfMoim(
             final Long moimId,
-            final Principal principal,
             @PathVariable("moimId") final String moimUrl
     );
 
@@ -157,7 +155,6 @@ public interface MoimControllerSwagger {
     )
     SuccessResponse<TemporaryPostExistResponse> getTemporaryPost(
             final Long moimId,
-            final Principal principal,
             @PathVariable("moimId") final String moimUrl
     );
 }

--- a/module-api/src/main/java/com/mile/controller/post/PostController.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostController.java
@@ -1,5 +1,6 @@
 package com.mile.controller.post;
 
+import com.mile.authentication.PrincipalHandler;
 import com.mile.curious.service.dto.CuriousInfoResponse;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
@@ -17,6 +18,7 @@ import com.mile.writerName.service.dto.WriterNameResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,18 +37,18 @@ import java.security.Principal;
 public class PostController implements PostControllerSwagger {
 
     private final PostService postService;
+    private final PrincipalHandler principalHandler;
 
     @PostMapping("/{postId}/comment")
     @Override
     public SuccessResponse postComment(
             @PostIdPathVariable final Long postId,
             @Valid @RequestBody final CommentCreateRequest commentCreateRequest,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     ) {
         postService.createCommentOnPost(
                 postId,
-                Long.valueOf(principal.getName()),
+                principalHandler.getUserIdFromPrincipal(),
                 commentCreateRequest
         );
         return SuccessResponse.of(SuccessMessage.COMMENT_CREATE_SUCCESS);
@@ -57,20 +59,18 @@ public class PostController implements PostControllerSwagger {
     @Override
     public SuccessResponse<PostCuriousResponse> postCurious(
             @PostIdPathVariable final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.CURIOUS_CREATE_SUCCESS, postService.createCuriousOnPost(postId, Long.valueOf(principal.getName())));
+        return SuccessResponse.of(SuccessMessage.CURIOUS_CREATE_SUCCESS, postService.createCuriousOnPost(postId, principalHandler.getUserIdFromPrincipal()));
     }
 
     @GetMapping("/{postId}/comment")
     @Override
     public SuccessResponse<CommentListResponse> getComments(
             @PostIdPathVariable final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.COMMENT_SEARCH_SUCCESS, postService.getComments(postId, Long.valueOf(principal.getName())));
+        return SuccessResponse.of(SuccessMessage.COMMENT_SEARCH_SUCCESS, postService.getComments(postId, principalHandler.getUserIdFromPrincipal()));
     }
 
 
@@ -78,30 +78,27 @@ public class PostController implements PostControllerSwagger {
     @Override
     public SuccessResponse<CuriousInfoResponse> getCuriousInfo(
             @PostIdPathVariable final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.CURIOUS_INFO_SEARCH_SUCCESS, postService.getCuriousInfo(postId, Long.valueOf(principal.getName())));
+        return SuccessResponse.of(SuccessMessage.CURIOUS_INFO_SEARCH_SUCCESS, postService.getCuriousInfo(postId, principalHandler.getUserIdFromPrincipal()));
     }
 
     @DeleteMapping("/{postId}/curious")
     @Override
     public SuccessResponse<PostCuriousResponse> deleteCurious(
             @PostIdPathVariable final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.CURIOUS_DELETE_SUCCESS, postService.deleteCuriousOnPost(postId, Long.valueOf(principal.getName())));
+        return SuccessResponse.of(SuccessMessage.CURIOUS_DELETE_SUCCESS, postService.deleteCuriousOnPost(postId, principalHandler.getUserIdFromPrincipal()));
     }
 
     @GetMapping("/{postId}/authenticate")
     @Override
     public SuccessResponse getAuthenticateWrite(
             @PostIdPathVariable final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.WRITER_AUTHENTIACTE_SUCCESS, postService.getAuthenticateWriter(postId, Long.valueOf(principal.getName())));
+        return SuccessResponse.of(SuccessMessage.WRITER_AUTHENTIACTE_SUCCESS, postService.getAuthenticateWriter(postId, principalHandler.getUserIdFromPrincipal()));
     }
 
     @PutMapping("/{postId}")
@@ -109,10 +106,9 @@ public class PostController implements PostControllerSwagger {
     public SuccessResponse putPost(
             @PostIdPathVariable final Long postId,
             @Valid @RequestBody final PostPutRequest putRequest,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     ) {
-        postService.updatePost(postId, Long.valueOf(principal.getName()), putRequest);
+        postService.updatePost(postId, principalHandler.getUserIdFromPrincipal(), putRequest);
         return SuccessResponse.of(SuccessMessage.POST_PUT_SUCCESS);
     }
 
@@ -120,10 +116,9 @@ public class PostController implements PostControllerSwagger {
     @Override
     public SuccessResponse deletePost(
             @PostIdPathVariable final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     ) {
-        postService.deletePost(postId, Long.valueOf(principal.getName()));
+        postService.deletePost(postId, principalHandler.getUserIdFromPrincipal());
         return SuccessResponse.of(SuccessMessage.POST_DELETE_SUCCESS);
     }
 
@@ -131,11 +126,10 @@ public class PostController implements PostControllerSwagger {
     @GetMapping("/temporary/{postId}")
     public SuccessResponse<TemporaryPostGetResponse> getTemporaryPost(
             @PostIdPathVariable final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     ) {
         return SuccessResponse.of(SuccessMessage.TEMPORARY_POST_GET_SUCCESS,
-                postService.getTemporaryPost(postId, Long.valueOf(principal.getName())));
+                postService.getTemporaryPost(postId, principalHandler.getUserIdFromPrincipal()));
     }
 
     @Override
@@ -151,22 +145,20 @@ public class PostController implements PostControllerSwagger {
     @Override
     @PostMapping
     public SuccessResponse<WriterNameResponse> createPost(
-            @Valid @RequestBody final PostCreateRequest postCreateRequest,
-            final Principal principal
+            @Valid @RequestBody final PostCreateRequest postCreateRequest
     ) {
         return SuccessResponse.of(SuccessMessage.POST_CREATE_SUCCESS, postService.createPost(
-                Long.valueOf(principal.getName()),
+                principalHandler.getUserIdFromPrincipal(),
                 postCreateRequest
         ));
     }
 
     @PostMapping("/temporary")
     public SuccessResponse createTemporaryPost(
-            @RequestBody final TemporaryPostCreateRequest temporaryPostCreateRequest,
-            final Principal principal
+            @RequestBody final TemporaryPostCreateRequest temporaryPostCreateRequest
     ) {
         postService.createTemporaryPost(
-                Long.valueOf(principal.getName()),
+                principalHandler.getUserIdFromPrincipal(),
                 temporaryPostCreateRequest
         );
         return SuccessResponse.of(SuccessMessage.TEMPORARY_POST_CREATE_SUCCESS);
@@ -175,12 +167,11 @@ public class PostController implements PostControllerSwagger {
     @PutMapping("/temporary/{postId}")
     public SuccessResponse<WriterNameResponse> putFixedPost(
             @PostIdPathVariable final Long postId,
-            final Principal principal,
             @RequestBody final PostPutRequest request,
             @PathVariable("postId") final String postUrl
     ) {
         return SuccessResponse.of(SuccessMessage.POST_CREATE_SUCCESS, postService.putFixedPost(
-                Long.valueOf(principal.getName()),
+                principalHandler.getUserIdFromPrincipal(),
                 request,
                 postId
         ));

--- a/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
@@ -44,7 +44,6 @@ public interface PostControllerSwagger {
     SuccessResponse postComment(
             final Long postId,
             @Valid @RequestBody final CommentCreateRequest commentCreateRequest,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     );
 
@@ -61,7 +60,6 @@ public interface PostControllerSwagger {
     )
     SuccessResponse<PostCuriousResponse> postCurious(
             final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     );
 
@@ -79,7 +77,6 @@ public interface PostControllerSwagger {
     )
     SuccessResponse<CommentListResponse> getComments(
             final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     );
 
@@ -96,7 +93,6 @@ public interface PostControllerSwagger {
     )
     SuccessResponse<CuriousInfoResponse> getCuriousInfo(
             final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     );
 
@@ -113,7 +109,6 @@ public interface PostControllerSwagger {
     )
     SuccessResponse<PostCuriousResponse> deleteCurious(
             final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     );
 
@@ -133,7 +128,6 @@ public interface PostControllerSwagger {
     )
     SuccessResponse getAuthenticateWrite(
             final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     );
 
@@ -163,7 +157,6 @@ public interface PostControllerSwagger {
     SuccessResponse putPost(
             final Long postId,
             @RequestBody final PostPutRequest putRequest,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     );
 
@@ -181,7 +174,6 @@ public interface PostControllerSwagger {
     )
     SuccessResponse deletePost(
             final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     );
 
@@ -197,7 +189,6 @@ public interface PostControllerSwagger {
     )
     SuccessResponse<TemporaryPostGetResponse> getTemporaryPost(
             final Long postId,
-            final Principal principal,
             @PathVariable("postId") final String postUrl
     );
 
@@ -233,8 +224,7 @@ public interface PostControllerSwagger {
             }
     )
     SuccessResponse createTemporaryPost(
-            @Valid @RequestBody final TemporaryPostCreateRequest temporaryPostCreateRequest,
-            final Principal principal
+            @Valid @RequestBody final TemporaryPostCreateRequest temporaryPostCreateRequest
     );
 
 
@@ -255,8 +245,7 @@ public interface PostControllerSwagger {
             }
     )
     SuccessResponse createPost(
-            @Valid @RequestBody final PostCreateRequest postCreateRequest,
-            final Principal principal
+            @Valid @RequestBody final PostCreateRequest postCreateRequest
     );
 
     @Operation(summary = "임시 저장된 글 작성")
@@ -270,7 +259,7 @@ public interface PostControllerSwagger {
 
             }
     )
-    SuccessResponse<WriterNameResponse> putFixedPost(final Long postId, final Principal principal,
+    SuccessResponse<WriterNameResponse> putFixedPost(final Long postId,
                                                      @RequestBody final PostPutRequest request,
                                                      @PathVariable("postId") final String postUrl);
 }

--- a/module-common/src/main/java/com/mile/authentication/PrincipalHandler.java
+++ b/module-common/src/main/java/com/mile/authentication/PrincipalHandler.java
@@ -1,0 +1,27 @@
+package com.mile.authentication;
+
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.UnauthorizedException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class PrincipalHandler {
+
+    private static final String ANONYMOUS_USER = "anonymousUser";
+
+    public Long getUserIdFromPrincipal() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        isPrincipalNull(principal);
+        return Long.valueOf(principal.toString());
+    }
+
+    public void isPrincipalNull(
+            final Object principal
+    ) {
+        if (principal.toString().equals(ANONYMOUS_USER)) {
+            throw new UnauthorizedException(ErrorMessage.UN_LOGIN_EXCEPTION);
+        }
+    }
+}

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -55,6 +55,7 @@ public enum ErrorMessage {
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED.value(), "액세스 토큰이 만료되었습니다."),
     TOKEN_INCORRECT_ERROR(HttpStatus.UNAUTHORIZED.value(), "리프레시 토큰이 유효하지 않습니다."),
     TOKEN_VALIDATION_ERROR(HttpStatus.UNAUTHORIZED.value(), "사용자 검증 토큰이 유효하지 않습니다."),
+    UN_LOGIN_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "로그인 후 진행해주세요."),
     /*
     Forbidden
      */

--- a/module-common/src/main/java/com/mile/utils/SecureUrlUtil.java
+++ b/module-common/src/main/java/com/mile/utils/SecureUrlUtil.java
@@ -7,11 +7,11 @@ import java.util.Base64;
 @Component
 public class SecureUrlUtil {
 
-    public String encodeUrl(Long meetingId) {
-        return  Base64.getUrlEncoder().encodeToString(meetingId.toString().getBytes());
+    public String encodeUrl(final Long id) {
+        return  Base64.getUrlEncoder().encodeToString(id.toString().getBytes());
     }
 
-    public Long decodeUrl(String url) {
+    public Long decodeUrl(final String url) {
         return Long.parseLong(new String(Base64.getUrlDecoder().decode(url)));
     }
 

--- a/module-domain/src/main/java/com/mile/comment/service/CommentService.java
+++ b/module-domain/src/main/java/com/mile/comment/service/CommentService.java
@@ -2,14 +2,15 @@ package com.mile.comment.service;
 
 import com.mile.comment.domain.Comment;
 import com.mile.comment.repository.CommentRepository;
+import com.mile.comment.service.dto.CommentResponse;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.ForbiddenException;
 import com.mile.exception.model.NotFoundException;
-import com.mile.comment.service.dto.CommentResponse;
 import com.mile.post.domain.Post;
 import com.mile.post.service.PostAuthenticateService;
 import com.mile.post.service.PostGetService;
 import com.mile.post.service.dto.CommentCreateRequest;
+import com.mile.utils.SecureUrlUtil;
 import com.mile.writerName.domain.WriterName;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ public class CommentService {
     private final PostAuthenticateService postAuthenticateService;
     private final CommentRepository commentRepository;
     private final PostGetService postGetService;
+    private final SecureUrlUtil secureUrlUtil;
 
     @Transactional
     public void deleteComment(
@@ -69,7 +71,7 @@ public class CommentService {
             final CommentCreateRequest commentCreateRequest
     ) {
         Comment comment = create(post, writerName, commentCreateRequest);
-        comment.setIdUrl(Base64.getEncoder().encodeToString(comment.getId().toString().getBytes()));
+        comment.setIdUrl(secureUrlUtil.encodeUrl(comment.getId()));
     }
 
     private Comment create(

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -25,6 +25,7 @@ import com.mile.topic.domain.Topic;
 import com.mile.topic.service.TopicService;
 import com.mile.topic.service.dto.ContentWithIsSelectedResponse;
 import com.mile.user.service.UserService;
+import com.mile.utils.SecureUrlUtil;
 import com.mile.writerName.domain.WriterName;
 import com.mile.writerName.service.WriterNameService;
 
@@ -49,6 +50,7 @@ public class PostService {
     private final UserService userService;
     private final TopicService topicService;
     private final S3Service s3Service;
+    private final SecureUrlUtil secureUrlUtil;
 
     public static final boolean TEMPRORARY_FALSE = false;
     public static final boolean TEMPORARY_TRUE = true;
@@ -223,7 +225,7 @@ public class PostService {
         WriterName writerName = writerNameService.findByMoimAndUser(decodeUrlToLong(postCreateRequest.moimId()), userId);
         Post post = createPost(postCreateRequest, writerName);
         postRepository.saveAndFlush(post);
-        post.setIdUrl(Base64.getUrlEncoder().encodeToString(post.getId().toString().getBytes()));
+        post.setIdUrl(secureUrlUtil.encodeUrl(post.getId()));
         return WriterNameResponse.of(post.getIdUrl(), writerName.getName());
     }
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #132 

## Key Changes 🔑
- 기존에 사용하던 principal.getName은 `NullPointerException` 을 발생시킬 수 있어 SecurityContenxt에서 Principal을 가져오는 방식으로 변경했습니다. 만일 로그인을 하지 않은 상태로 API 요청을 하게 되면 anonymousUser가 되기 때문에 이를 검사하고 체크해주는 로직으로 변경했습니다.
- 또한, url인코딩 로직을 분리하고 이를 사용했습니다! 

## To Reviewers 📢
- 아자자!
