### PR TITLE
#197 [fix] 임시저장글이 글 리스트에서 조회되는 에러 해결

### DIFF
--- a/module-domain/src/main/java/com/mile/post/repository/PostRepositoryCustom.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepositoryCustom.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface PostRepositoryCustom {
     List<Post> findTop2ByMoimOrderByCuriousCountDesc(final Moim requestMoim);
-    List<Post> findLatest4PostsByMoim(Moim moim);
+    List<Post> findLatest4NonTemporaryPostsByMoim(Moim moim);
     List<Post> findByMoimAndWriterNameWhereIsTemporary(final Moim moim, final WriterName writerName);
 }
 

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepositoryImpl.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepositoryImpl.java
@@ -30,12 +30,12 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
     }
 
-    public List<Post> findLatest4PostsByMoim(Moim moim) {
+    public List<Post> findLatest4NonTemporaryPostsByMoim(Moim moim) {
 
         List<Post> result = jpaQueryFactory
                 .select(post)
                 .from(post)
-                .where(post.topic.moim.eq(moim))
+                .where(post.topic.moim.eq(moim).and(post.isTemporary.eq(false)))
                 .orderBy(post.createdAt.desc())
                 .limit(4)
                 .fetch();

--- a/module-domain/src/main/java/com/mile/post/service/PostGetService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostGetService.java
@@ -33,12 +33,13 @@ public class PostGetService {
             final Topic topic
     ) {
         List<Post> postList = postRepository.findByTopic(topic);
+        postList.removeIf(post -> post.isTemporary() == true);
         return postList.stream()
                 .sorted(Comparator.comparing(BaseTimeEntity::getCreatedAt).reversed()).collect(Collectors.toList());
     }
 
 
     public List<Post> getLatestPostsByMoim(Moim moim) {
-        return postRepository.findLatest4PostsByMoim(moim);
+        return postRepository.findLatest4NonTemporaryPostsByMoim(moim);
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #197 

## Key Changes 🔑
글 모임 뷰 - 글감별 글 리스트,
메인 뷰 - 베스트 모임 글 리스트에서
임시저장글이 조회되는 버그를 발견하고 해결하였습니다

## To Reviewers 📢
-
