### PR TITLE
#207 [refactor] 글 수정 API 엔드포인트 수정 및 서비스 분리

### DIFF
--- a/module-api/src/main/java/com/mile/controller/post/PostController.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostController.java
@@ -163,12 +163,12 @@ public class PostController implements PostControllerSwagger {
     }
 
     @PutMapping("/temporary/{postId}")
-    public SuccessResponse<WriterNameResponse> putFixedPost(
+    public SuccessResponse<WriterNameResponse> putTemporaryToFixedPost(
             @PostIdPathVariable final Long postId,
             @RequestBody final PostPutRequest request,
             @PathVariable("postId") final String postUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.POST_CREATE_SUCCESS, postService.putFixedPost(
+        return SuccessResponse.of(SuccessMessage.POST_CREATE_SUCCESS, postService.putTemporaryToFixedPost(
                 principalHandler.getUserIdFromPrincipal(),
                 request,
                 postId
@@ -177,12 +177,12 @@ public class PostController implements PostControllerSwagger {
 
     @Override
     @GetMapping("/modify/{postId}")
-    public SuccessResponse<ModifyPostGetResponse> getModifyPost(
+    public SuccessResponse<ModifyPostGetResponse> getPostForModifying(
             @PostIdPathVariable final Long postId,
             @PathVariable("postId") final String postUrl
     ) {
         return SuccessResponse.of(SuccessMessage.MODIFY_POST_GET_SUCCESS,
-                postService.getModifyPost(postId, principalHandler.getUserIdFromPrincipal()));
+                postService.getPostForModifying(postId, principalHandler.getUserIdFromPrincipal()));
     }
 
 }

--- a/module-api/src/main/java/com/mile/controller/post/PostController.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostController.java
@@ -18,6 +18,8 @@ import com.mile.resolver.post.PostIdPathVariable;
 import com.mile.writername.service.dto.WriterNameResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -99,13 +101,13 @@ public class PostController implements PostControllerSwagger {
 
     @PutMapping("/{postId}")
     @Override
-    public SuccessResponse putPost(
+    public ResponseEntity<SuccessResponse> putPost(
             @PostIdPathVariable final Long postId,
             @Valid @RequestBody final PostPutRequest putRequest,
             @PathVariable("postId") final String postUrl
     ) {
         postService.updatePost(postId, principalHandler.getUserIdFromPrincipal(), putRequest);
-        return SuccessResponse.of(SuccessMessage.POST_PUT_SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.of(SuccessMessage.POST_PUT_SUCCESS));
     }
 
     @DeleteMapping("/{postId}")

--- a/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -155,7 +156,7 @@ public interface PostControllerSwagger {
 
             }
     )
-    SuccessResponse putPost(
+    ResponseEntity<SuccessResponse> putPost(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long postId,
             @RequestBody final PostPutRequest putRequest,
             @PathVariable("postId") final String postUrl

--- a/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
@@ -262,7 +262,7 @@ public interface PostControllerSwagger {
 
             }
     )
-    SuccessResponse<WriterNameResponse> putFixedPost(
+    SuccessResponse<WriterNameResponse> putTemporaryToFixedPost(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long postId,
             @RequestBody final PostPutRequest request,
             @PathVariable("postId") final String postUrl
@@ -278,7 +278,7 @@ public interface PostControllerSwagger {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
-    SuccessResponse<ModifyPostGetResponse> getModifyPost(
+    SuccessResponse<ModifyPostGetResponse> getPostForModifying(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long postId,
             @PathVariable("postId") final String postUrl
     );

--- a/module-domain/src/main/java/com/mile/post/domain/Post.java
+++ b/module-domain/src/main/java/com/mile/post/domain/Post.java
@@ -81,17 +81,20 @@ public class Post extends BaseTimeEntity {
 
     public void updatePost(
             final Topic topic,
-            final PostPutRequest putRequest,
-            final boolean isTemporary
+            final PostPutRequest putRequest
     ) {
         this.topic = topic;
         this.title = putRequest.title();
         this.content = putRequest.content();
         this.imageUrl = putRequest.imageUrl();
         this.anonymous = putRequest.anonymous();
-        this.isTemporary = isTemporary;
     }
 
+    public void setTemporary(
+            final boolean isTemporary
+    ) {
+        this.isTemporary = isTemporary;
+    }
     public void setIdUrl(
             final String idUrl
     ) {

--- a/module-domain/src/main/java/com/mile/post/service/PostGetService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostGetService.java
@@ -33,7 +33,7 @@ public class PostGetService {
             final Topic topic
     ) {
         List<Post> postList = postRepository.findByTopic(topic);
-        postList.removeIf(post -> post.isTemporary() == true);
+        postList.removeIf(Post::isTemporary);
         return postList.stream()
                 .sorted(Comparator.comparing(BaseTimeEntity::getCreatedAt).reversed()).collect(Collectors.toList());
     }

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -41,6 +41,8 @@ import java.util.List;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final PostUpdateService postUpdateService;
+    private final PostGetService postGetService;
     private final PostAuthenticateService postAuthenticateService;
     private final CommentService commentService;
     private final WriterNameService writerNameService;
@@ -63,7 +65,7 @@ public class PostService {
             final CommentCreateRequest commentCreateRequest
 
     ) {
-        Post post = findById(postId);
+        Post post = postGetService.findById(postId);
         Long moimId = post.getTopic().getMoim().getId();
         postAuthenticateService.authenticateUserWithPost(post, userId);
         commentService.createComment(post, writerNameService.findByMoimAndUser(moimId, userId), commentCreateRequest);
@@ -75,7 +77,7 @@ public class PostService {
             final Long postId,
             final Long userId
     ) {
-        Post post = findById(postId);
+        Post post = postGetService.findById(postId);
         postAuthenticateService.authenticateUserWithPost(post, userId);
         curiousService.createCurious(post, userService.findById(userId));
         return PostCuriousResponse.of(CURIOUS_TRUE);
@@ -89,21 +91,13 @@ public class PostService {
     }
 
 
-    public Post findById(
-            final Long postId
-    ) {
-        return postRepository.findById(postId)
-                .orElseThrow(
-                        () -> new NotFoundException(ErrorMessage.POST_NOT_FOUND)
-                );
-    }
 
     @Transactional(readOnly = true)
     public CuriousInfoResponse getCuriousInfo(
             final Long postId,
             final Long userId
     ) {
-        Post post = findById(postId);
+        Post post = postGetService.findById(postId);
         postAuthenticateService.authenticateUserWithPost(post, userId);
         return curiousService.getCuriousInfoResponse(post, userService.findById(userId));
     }
@@ -113,30 +107,21 @@ public class PostService {
             final Long postId,
             final Long userId
     ) {
-        Post post = findById(postId);
+        Post post = postGetService.findById(postId);
         postAuthenticateService.authenticateUserWithPost(post, userId);
         curiousService.deleteCurious(post, userService.findById(userId));
         return PostCuriousResponse.of(CURIOUS_FALSE);
     }
 
-    @Transactional
     public void updatePost(
             final Long postId,
             final Long userId,
             final PostPutRequest putRequest
     ) {
-        Post post = findById(postId);
+        Post post = postGetService.findById(postId);
         postAuthenticateService.authenticateWriter(postId, userId);
         Topic topic = topicService.findById(decodeUrlToLong(putRequest.topicId()));
-        update(post, topic, putRequest);
-    }
-
-    private void update(
-            final Post post,
-            final Topic topic,
-            final PostPutRequest putRequest
-    ) {
-        post.updatePost(topic, putRequest, post.isTemporary());
+        postUpdateService.update(post, topic, putRequest);
     }
 
     public WriterAuthenticateResponse getAuthenticateWriter(
@@ -158,7 +143,7 @@ public class PostService {
     private void delete(
             final Long postId
     ) {
-        Post post = findById(postId);
+        Post post = postGetService.findById(postId);
         deleteRelatedData(post);
         postRepository.delete(post);
     }
@@ -184,7 +169,7 @@ public class PostService {
             final Long postId,
             final Long userId
     ) {
-        Post post = findById(postId);
+        Post post = postGetService.findById(postId);
         postAuthenticateService.authenticateUserWithPost(post, userId);
         isPostTemporary(post);
 
@@ -203,7 +188,7 @@ public class PostService {
     public PostGetResponse getPost(
             final Long postId
     ) {
-        Post post = findById(postId);
+        Post post = postGetService.findById(postId);
         Moim moim = post.getTopic().getMoim();
         return PostGetResponse.of(post, moim);
     }
@@ -268,7 +253,7 @@ public class PostService {
     @Transactional
     public WriterNameResponse putFixedPost(final Long userId, final PostPutRequest request, final Long postId) {
         postAuthenticateService.authenticateWriter(postId, userId);
-        Post post = findById(postId);
+        Post post = postGetService.findById(postId);
         isPostTemporary(post);
         post.updatePost(topicService.findById(decodeUrlToLong(request.topicId())), request, false);
         return WriterNameResponse.of(post.getIdUrl(), post.getWriterName().getName());
@@ -279,7 +264,7 @@ public class PostService {
             final Long postId,
             final Long userId
     ) {
-        Post post = findById(postId);
+        Post post = postGetService.findById(postId);
         postAuthenticateService.authenticateUserWithPost(post, userId);
         isPostNotTemporary(post);
 

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -6,7 +6,6 @@ import com.mile.curious.service.CuriousService;
 import com.mile.curious.service.dto.CuriousInfoResponse;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.BadRequestException;
-import com.mile.exception.model.NotFoundException;
 import com.mile.moim.domain.Moim;
 import com.mile.post.domain.Post;
 import com.mile.post.repository.PostRepository;
@@ -245,22 +244,23 @@ public class PostService {
         post.setIdUrl(Base64.getUrlEncoder().encodeToString(post.getId().toString().getBytes()));
     }
 
-    private boolean checkContainPhoto(String imageUrl) {
+    private boolean checkContainPhoto(final String imageUrl) {
         return !imageUrl.equals(DEFAULT_IMG_URL);
     }
 
 
     @Transactional
-    public WriterNameResponse putFixedPost(final Long userId, final PostPutRequest request, final Long postId) {
+    public WriterNameResponse putTemporaryToFixedPost(final Long userId, final PostPutRequest request, final Long postId) {
         postAuthenticateService.authenticateWriter(postId, userId);
         Post post = postGetService.findById(postId);
         isPostTemporary(post);
-        post.updatePost(topicService.findById(decodeUrlToLong(request.topicId())), request, false);
+        updatePost(postId, userId, request);
+        post.setTemporary(false);
         return WriterNameResponse.of(post.getIdUrl(), post.getWriterName().getName());
     }
 
     @Transactional(readOnly = true)
-    public ModifyPostGetResponse getModifyPost(
+    public ModifyPostGetResponse getPostForModifying(
             final Long postId,
             final Long userId
     ) {

--- a/module-domain/src/main/java/com/mile/post/service/PostUpdateService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostUpdateService.java
@@ -1,9 +1,23 @@
 package com.mile.post.service;
 
+import com.mile.post.domain.Post;
+import com.mile.post.service.dto.PostPutRequest;
+import com.mile.topic.domain.Topic;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PostUpdateService {
+
+    @Transactional
+    public void update(
+            final Post post,
+            final Topic topic,
+            final PostPutRequest putRequest
+    ) {
+        post.updatePost(topic, putRequest, post.isTemporary());
+    }
+
 }

--- a/module-domain/src/main/java/com/mile/post/service/PostUpdateService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostUpdateService.java
@@ -17,7 +17,7 @@ public class PostUpdateService {
             final Topic topic,
             final PostPutRequest putRequest
     ) {
-        post.updatePost(topic, putRequest, post.isTemporary());
+        post.updatePost(topic, putRequest);
     }
 
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #207 

## Key Changes 🔑
1. 람다식 수정
2. API 엔드포인트 수정
3. 서비스 로직 분리
4. 기존에 updatePost에 의미없는 isTemporary 값을 받아오는 것을 setTemporary 메서드로 분리한 후, updatePost를 순수하게 update만 할 수 있게 유지했습니다.

## To Reviewers 📢
- 우선 수정 API 위주로만 보았는데 고쳐야할 부분이 다른 데에도 많네요! 😅
