### PR TITLE
#211 [refactor] 글 삭제 api 리팩토링

### DIFF
--- a/module-api/src/main/java/com/mile/controller/post/PostController.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostController.java
@@ -112,12 +112,12 @@ public class PostController implements PostControllerSwagger {
 
     @DeleteMapping("/{postId}")
     @Override
-    public SuccessResponse deletePost(
+    public ResponseEntity<SuccessResponse> deletePost(
             @PostIdPathVariable final Long postId,
             @PathVariable("postId") final String postUrl
     ) {
         postService.deletePost(postId, principalHandler.getUserIdFromPrincipal());
-        return SuccessResponse.of(SuccessMessage.POST_DELETE_SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.of(SuccessMessage.POST_DELETE_SUCCESS));
     }
 
     @Override

--- a/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
@@ -174,7 +174,7 @@ public interface PostControllerSwagger {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
-    SuccessResponse deletePost(
+    ResponseEntity<SuccessResponse> deletePost(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long postId,
             @PathVariable("postId") final String postUrl
     );

--- a/module-domain/src/main/java/com/mile/comment/repository/CommentRepository.java
+++ b/module-domain/src/main/java/com/mile/comment/repository/CommentRepository.java
@@ -3,6 +3,7 @@ package com.mile.comment.repository;
 import com.mile.comment.domain.Comment;
 import com.mile.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,5 +16,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByPostId(final Long postId);
 
-    void deleteAllByPost(final Post post);
+    @Modifying
+    @Query("delete from Comment c where c.post = :post")
+    void deleteAllByPost(@Param("post")final Post post);
 }

--- a/module-domain/src/main/java/com/mile/curious/repository/CuriousRepository.java
+++ b/module-domain/src/main/java/com/mile/curious/repository/CuriousRepository.java
@@ -3,10 +3,15 @@ import com.mile.curious.domain.Curious;
 import com.mile.post.domain.Post;
 import com.mile.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CuriousRepository extends JpaRepository<Curious, Long> {
     boolean existsByPostAndUser(Post post, User user);
     Curious findByPostAndUser(Post post, User user);
 
-    void deleteAllByPost(final Post post);
+    @Modifying
+    @Query("delete from Curious c where c.post = :post")
+    void deleteAllByPost(@Param("post") final Post post);
 }

--- a/module-domain/src/main/java/com/mile/post/service/PostDeleteService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostDeleteService.java
@@ -1,5 +1,8 @@
 package com.mile.post.service;
 
+import com.mile.aws.utils.S3Service;
+import com.mile.comment.service.CommentService;
+import com.mile.curious.service.CuriousService;
 import com.mile.moim.domain.Moim;
 import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimMostCuriousPostResponse;
@@ -16,7 +19,9 @@ import java.util.stream.Collectors;
 public class PostDeleteService {
 
     private final PostRepository postRepository;
-
+    private final CuriousService curiousService;
+    private final CommentService commentService;
+    private final S3Service s3Service;
     private List<Post> getPostHaveCuriousCount(
             final List<Post> postList
     ) {
@@ -24,6 +29,27 @@ public class PostDeleteService {
         return postList;
     }
 
+    public void delete(
+            final Post post
+    ) {
+        deleteRelatedData(post);
+        postRepository.delete(post);
+    }
+    private void deleteRelatedData(
+            final Post post
+    ) {
+        if (post.isContainPhoto()) {
+            deleteS3File(post.getImageUrl());
+        }
+        curiousService.deleteAllByPost(post);
+        commentService.deleteAllByPost(post);
+    }
+
+    private void deleteS3File(
+            final String key
+    ) {
+        s3Service.deleteImage(key);
+    }
     public MoimCuriousPostListResponse getMostCuriousPostByMoim(final Moim moim) {
         List<Post> postList = getPostHaveCuriousCount(postRepository.findTop2ByMoimOrderByCuriousCountDesc(moim));
         return MoimCuriousPostListResponse.of(postList

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -48,7 +48,7 @@ public class PostService {
     private final CuriousService curiousService;
     private final UserService userService;
     private final TopicService topicService;
-    private final S3Service s3Service;
+    private final PostDeleteService postDeleteService;
     private final SecureUrlUtil secureUrlUtil;
 
     private static final boolean TEMPRORARY_FALSE = false;
@@ -136,32 +136,10 @@ public class PostService {
             final Long userId
     ) {
         postAuthenticateService.authenticateWriter(postId, userId);
-        delete(postId);
-    }
-
-    private void delete(
-            final Long postId
-    ) {
         Post post = postGetService.findById(postId);
-        deleteRelatedData(post);
-        postRepository.delete(post);
+        postDeleteService.delete(post);
     }
 
-    private void deleteRelatedData(
-            final Post post
-    ) {
-        if (post.isContainPhoto()) {
-            deleteS3File(post.getImageUrl());
-        }
-        curiousService.deleteAllByPost(post);
-        commentService.deleteAllByPost(post);
-    }
-
-    private void deleteS3File(
-            final String key
-    ) {
-        s3Service.deleteImage(key);
-    }
 
     @Transactional(readOnly = true)
     public TemporaryPostGetResponse getTemporaryPost(


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #211 

## Key Changes 🔑
1. ResponseEntity 추가
2. 기존에 글 삭제를 진행하면서 관련 데이터를 삭제하던 쿼리문의 최대 개수는 무한대였습니다! 
![image](https://github.com/Mile-Writings/Mile-Server/assets/79795051/a67bddfb-7b0f-4a2e-9c39-c6dd27fd6601)
이를 batch delete 방식을 선택하여 `@Query`를 사용하여 쿼리문을 최대 3개로 줄였습니다! 
![image](https://github.com/Mile-Writings/Mile-Server/assets/79795051/96f777ed-e135-4d86-a1ca-36a998af7192)

## To Reviewers 📢
-
