### PR TITLE
#232 [refactor] 임시 저장된 글 작성 API & 글 수정 삭제 권한 확인 API 리팩토링

### DIFF
--- a/module-api/src/main/java/com/mile/controller/post/PostController.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostController.java
@@ -16,6 +16,7 @@ import com.mile.post.service.dto.TemporaryPostCreateRequest;
 import com.mile.post.service.dto.TemporaryPostGetResponse;
 import com.mile.resolver.post.PostIdPathVariable;
 import com.mile.writername.service.dto.WriterNameResponse;
+import feign.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -92,11 +93,11 @@ public class PostController implements PostControllerSwagger {
 
     @GetMapping("/{postId}/authenticate")
     @Override
-    public SuccessResponse getAuthenticateWrite(
+    public ResponseEntity<SuccessResponse> getAuthenticateWrite(
             @PostIdPathVariable final Long postId,
             @PathVariable("postId") final String postUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.WRITER_AUTHENTIACTE_SUCCESS, postService.getAuthenticateWriter(postId, principalHandler.getUserIdFromPrincipal()));
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.WRITER_AUTHENTIACTE_SUCCESS, postService.getAuthenticateWriter(postId, principalHandler.getUserIdFromPrincipal())));
     }
 
     @PutMapping("/{postId}")
@@ -163,16 +164,16 @@ public class PostController implements PostControllerSwagger {
     }
 
     @PutMapping("/temporary/{postId}")
-    public SuccessResponse<WriterNameResponse> putTemporaryToFixedPost(
+    public ResponseEntity<SuccessResponse<WriterNameResponse>> putTemporaryToFixedPost(
             @PostIdPathVariable final Long postId,
             @RequestBody final PostPutRequest request,
             @PathVariable("postId") final String postUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.POST_CREATE_SUCCESS, postService.putTemporaryToFixedPost(
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.POST_CREATE_SUCCESS, postService.putTemporaryToFixedPost(
                 principalHandler.getUserIdFromPrincipal(),
                 request,
                 postId
-        ));
+        )));
     }
 
     @Override

--- a/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostControllerSwagger.java
@@ -128,7 +128,7 @@ public interface PostControllerSwagger {
 
             }
     )
-    SuccessResponse getAuthenticateWrite(
+    ResponseEntity<SuccessResponse> getAuthenticateWrite(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long postId,
             @PathVariable("postId") final String postUrl
     );
@@ -262,7 +262,7 @@ public interface PostControllerSwagger {
 
             }
     )
-    SuccessResponse<WriterNameResponse> putTemporaryToFixedPost(
+    ResponseEntity<SuccessResponse<WriterNameResponse>> putTemporaryToFixedPost(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long postId,
             @RequestBody final PostPutRequest request,
             @PathVariable("postId") final String postUrl

--- a/module-domain/src/main/java/com/mile/moim/domain/Moim.java
+++ b/module-domain/src/main/java/com/mile/moim/domain/Moim.java
@@ -4,6 +4,7 @@ import com.mile.config.BaseTimeEntity;
 import com.mile.writername.domain.WriterName;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -16,7 +17,7 @@ public class Moim extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private WriterName owner;
     private String name;
     private String imageUrl;

--- a/module-domain/src/main/java/com/mile/post/domain/Post.java
+++ b/module-domain/src/main/java/com/mile/post/domain/Post.java
@@ -6,6 +6,7 @@ import com.mile.topic.domain.Topic;
 import com.mile.writername.domain.WriterName;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,9 +26,9 @@ public class Post extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Topic topic;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private WriterName writerName;
     private String title;
     @Column(length = 50000)

--- a/module-domain/src/main/java/com/mile/post/service/PostAuthenticateService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostAuthenticateService.java
@@ -5,6 +5,7 @@ import com.mile.exception.model.ForbiddenException;
 import com.mile.exception.model.NotFoundException;
 import com.mile.post.domain.Post;
 import com.mile.post.repository.PostRepository;
+import com.mile.writername.domain.WriterName;
 import com.mile.writername.service.WriterNameService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -49,20 +50,29 @@ public class PostAuthenticateService {
                 );
     }
 
-    public boolean authenticateWriterWithPost(
+    public boolean existsPostByWriterWithPost(
             final Long postId,
-            final Long userId
+            final Long writerNameId
     ) {
-        return postRepository.existsPostByIdAndWriterNameId(postId, writerNameService.findByWriterId(userId).getId());
+        return postRepository.existsPostByIdAndWriterNameId(postId, writerNameId);
     }
 
-    public void authenticateWriter(
+    public void authenticateWriterWithPost(
+            final Long postId,
+            final Long writerNameId
+    ) {
+        if(!existsPostByWriterWithPost(postId, writerNameId)) {
+            throw new ForbiddenException(ErrorMessage.WRITER_AUTHENTICATE_ERROR);
+        }
+    }
+
+    public WriterName authenticateWriter(
             final Long postId,
             final Long userId
     ) {
-        if (!authenticateWriterWithPost(postId,userId)) {
-            throw new ForbiddenException(ErrorMessage.WRITER_AUTHENTICATE_ERROR);
-        }
+        WriterName writerName = writerNameService.getWriterNameIdByPostAndUserId(findById(postId), userId);
+        authenticateWriterWithPost(postId, writerName.getId());
+        return writerName;
     }
 
 

--- a/module-domain/src/main/java/com/mile/post/service/PostAuthenticateService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostAuthenticateService.java
@@ -70,7 +70,7 @@ public class PostAuthenticateService {
             final Long postId,
             final Long userId
     ) {
-        WriterName writerName = writerNameService.getWriterNameIdByPostAndUserId(findById(postId), userId);
+        WriterName writerName = writerNameService.getWriterNameByPostAndUserId(findById(postId), userId);
         authenticateWriterWithPost(postId, writerName.getId());
         return writerName;
     }

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -1,6 +1,5 @@
 package com.mile.post.service;
 
-import com.mile.aws.utils.S3Service;
 import com.mile.comment.service.CommentService;
 import com.mile.curious.service.CuriousService;
 import com.mile.curious.service.dto.CuriousInfoResponse;
@@ -51,7 +50,7 @@ public class PostService {
     private final PostDeleteService postDeleteService;
     private final SecureUrlUtil secureUrlUtil;
 
-    private static final boolean TEMPRORARY_FALSE = false;
+    private static final boolean TEMPORARY_FALSE = false;
     private static final boolean TEMPORARY_TRUE = true;
     private static final boolean CURIOUS_FALSE = false;
     private static final boolean CURIOUS_TRUE = true;
@@ -70,7 +69,6 @@ public class PostService {
         commentService.createComment(post, writerNameService.findByMoimAndUser(moimId, userId), commentCreateRequest);
     }
 
-
     @Transactional
     public PostCuriousResponse createCuriousOnPost(
             final Long postId,
@@ -88,8 +86,6 @@ public class PostService {
     ) {
         return CommentListResponse.of(commentService.getCommentResponse(postId, userId));
     }
-
-
 
     @Transactional(readOnly = true)
     public CuriousInfoResponse getCuriousInfoOfPost(
@@ -118,7 +114,16 @@ public class PostService {
             final PostPutRequest putRequest
     ) {
         Post post = postGetService.findById(postId);
-        postAuthenticateService.authenticateWriter(postId, userId);
+        postAuthenticateService.authenticateWriterWithPost(postId, userId);
+        Topic topic = topicService.findById(decodeUrlToLong(putRequest.topicId()));
+        postUpdateService.update(post, topic, putRequest);
+    }
+
+    private void updateTemporaryPost(
+            final Long postId,
+            final PostPutRequest putRequest
+    ) {
+        Post post = postGetService.findById(postId);
         Topic topic = topicService.findById(decodeUrlToLong(putRequest.topicId()));
         postUpdateService.update(post, topic, putRequest);
     }
@@ -127,7 +132,8 @@ public class PostService {
             final Long postId,
             final Long userId
     ) {
-        return WriterAuthenticateResponse.of(postAuthenticateService.authenticateWriterWithPost(postId, userId));
+        return WriterAuthenticateResponse.of(postAuthenticateService.existsPostByWriterWithPost(postId,
+                writerNameService.getWriterNameIdByPostAndUserId(postGetService.findById(postId), userId).getId()));
     }
 
     @Transactional
@@ -135,7 +141,7 @@ public class PostService {
             final Long postId,
             final Long userId
     ) {
-        postAuthenticateService.authenticateWriter(postId, userId);
+        postAuthenticateService.authenticateWriterWithPost(postId, userId);
         Post post = postGetService.findById(postId);
         postDeleteService.delete(post);
     }
@@ -149,7 +155,6 @@ public class PostService {
         Post post = postGetService.findById(postId);
         postAuthenticateService.authenticateUserWithPost(post, userId);
         isPostTemporary(post);
-
         List<ContentWithIsSelectedResponse> contentResponse = topicService.getContentsWithIsSelectedFromMoim(post.getTopic().getMoim().getId(), post.getTopic().getId());
         return TemporaryPostGetResponse.of(post, contentResponse);
     }
@@ -199,7 +204,7 @@ public class PostService {
                 postCreateRequest.imageUrl(),
                 checkContainPhoto(postCreateRequest.imageUrl()),
                 postCreateRequest.anonymous(),
-                TEMPRORARY_FALSE
+                TEMPORARY_FALSE
         );
     }
 
@@ -226,15 +231,14 @@ public class PostService {
         return !imageUrl.equals(DEFAULT_IMG_URL);
     }
 
-
     @Transactional
     public WriterNameResponse putTemporaryToFixedPost(final Long userId, final PostPutRequest request, final Long postId) {
-        postAuthenticateService.authenticateWriter(postId, userId);
+        WriterName writerName = postAuthenticateService.authenticateWriter(postId, userId);
         Post post = postGetService.findById(postId);
         isPostTemporary(post);
-        updatePost(postId, userId, request);
-        post.setTemporary(false);
-        return WriterNameResponse.of(post.getIdUrl(), post.getWriterName().getName());
+        updateTemporaryPost(postId, request);
+        post.setTemporary(TEMPORARY_FALSE);
+        return WriterNameResponse.of(post.getIdUrl(), writerName.getName());
     }
 
     @Transactional(readOnly = true)
@@ -245,7 +249,6 @@ public class PostService {
         Post post = postGetService.findById(postId);
         postAuthenticateService.authenticateUserWithPost(post, userId);
         isPostNotTemporary(post);
-
         List<ContentWithIsSelectedResponse> contentResponse = topicService.getContentsWithIsSelectedFromMoim(post.getTopic().getMoim().getId(), post.getTopic().getId());
         return ModifyPostGetResponse.of(post, contentResponse);
     }

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -133,7 +133,7 @@ public class PostService {
             final Long userId
     ) {
         return WriterAuthenticateResponse.of(postAuthenticateService.existsPostByWriterWithPost(postId,
-                writerNameService.getWriterNameIdByPostAndUserId(postGetService.findById(postId), userId).getId()));
+                writerNameService.getWriterNameByPostAndUserId(postGetService.findById(postId), userId).getId()));
     }
 
     @Transactional

--- a/module-domain/src/main/java/com/mile/topic/domain/Topic.java
+++ b/module-domain/src/main/java/com/mile/topic/domain/Topic.java
@@ -3,6 +3,7 @@ package com.mile.topic.domain;
 import com.mile.config.BaseTimeEntity;
 import com.mile.moim.domain.Moim;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -15,7 +16,7 @@ public class Topic extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Moim moim;
     private String idUrl;
     private String keyword;

--- a/module-domain/src/main/java/com/mile/topic/repository/TopicRepository.java
+++ b/module-domain/src/main/java/com/mile/topic/repository/TopicRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface TopicRepository extends JpaRepository<Topic, Long>, TopicRepositoryCustom {
 
-    public List<Topic> findByMoimId(final Long moimId);
+    List<Topic> findByMoimId(final Long moimId);
 }

--- a/module-domain/src/main/java/com/mile/writername/domain/WriterName.java
+++ b/module-domain/src/main/java/com/mile/writername/domain/WriterName.java
@@ -3,6 +3,7 @@ package com.mile.writername.domain;
 import com.mile.moim.domain.Moim;
 import com.mile.user.domain.User;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,13 +20,13 @@ public class WriterName {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Moim moim;
 
     private String name;
     private String information;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private User writer;
 
     private Integer totalCuriousCount;

--- a/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
+++ b/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 public interface WriterNameRepository extends JpaRepository<WriterName, Long> {
 
     Optional<WriterName> findByMoimIdAndWriterId(final Long moimId, final Long userId);
+    boolean existsWriterNameByMoimIdAndWriterId(final Long moimId, final Long userId);
 
     List<WriterName> findByMoimId(final Long moimId);
 

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -43,7 +43,7 @@ public class WriterNameService {
                 );
     }
 
-    public WriterName getWriterNameIdByPostAndUserId(
+    public WriterName getWriterNameByPostAndUserId(
             final Post post,
             final Long userId
     ) {

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -3,6 +3,7 @@ package com.mile.writername.service;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.NotFoundException;
 import com.mile.moim.domain.Moim;
+import com.mile.post.domain.Post;
 import com.mile.user.domain.User;
 import com.mile.writername.domain.WriterName;
 import com.mile.writername.repository.WriterNameRepository;
@@ -24,7 +25,7 @@ public class WriterNameService {
             final Long moimId,
             final Long writerId
     ) {
-        return writerNameRepository.findByMoimIdAndWriterId(moimId, writerId).isPresent();
+        return writerNameRepository.existsWriterNameByMoimIdAndWriterId(moimId, writerId);
     }
 
     public Long getWriterNameIdByUserId(
@@ -42,6 +43,15 @@ public class WriterNameService {
                 );
     }
 
+    public WriterName getWriterNameIdByPostAndUserId(
+            final Post post,
+            final Long userId
+    ) {
+        return writerNameRepository.findByMoimIdAndWriterId(post.getTopic().getMoim().getId(), userId)
+                .orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.WRITER_NOT_FOUND)
+                );
+    }
     public int findNumbersOfWritersByMoimId(
             final Long moimId
     ) {


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #232 

## Key Changes 🔑
1. 버그가 있었습니다! 무엇이냐면.. 저희가 writerName을 받아올 때 userId 하나로 받아오고 있더라고요! 
```java
Optional<WriterName> findByWriterId(final Long userId);
```
그래서 이 부분을 제거하고 `findByMoimIdAndWriterId`를 사용하는 방식으로 수정했습니다.
이 코드가 사용되고 있는 곳이 많습니다..! 리팩토링하면서 이 부분 버그 해결하면서 해결해주세요! 현재는 moim이 하나인 관계로 괜찮지만, moim이 여러개가 될 경우 userId로만 찾아오면 여러 개의 writerName이 존재해서 버그가 발생합니다! 히정님 코드에도 사용하고 있는 부분이 있더라고요! 저도 계속해서 수정할테니 참고해주세요!

2. 기존에 임시 저장된 글 작성 API에서 쿼리문이 6개가 나오고 있었는데요, writerName을 select 해오는 쿼리가 2번 나가더라고요! 그래서 WriterName 객체에 받아와서 이를 다시 사용하는 방법으로 한 번만 나가도록 수정했습니다! 총 4개로 수정! 이와 관련해서 비정규화를 하는 방향은 어떨지 생각이 드네요! Post안에 논리적 연관관계를 통해 MoimId를 넣어놓는 방법으로요!

3. 이 전에는 엔티티에 연관관계가 존재할 경우 fetchtype이 default인 eager로 불러오고 있었는데요, 불필요한 left join 쿼리 때문에 현업에서는 lazy를 기본으로 사용한다고 합니다! 저도 역시 이 방법으로 변경하였습니다!

4. 자잘한 코드 오류 사항이나 오타 변경
5. Optional.isPresent를 사용하던 방법을 exists 쿼리로 변경했습니다!

## To Reviewers 📢
- 임시 저장된 글 작성 API 수정하다가, 검증 방식 리팩토링 진행하면서 글 수정 삭제 권한 API까지 리팩토링 했습니다! pr이 크네요..! 양해 부탁드려요!
