### PR TITLE
#247 [feat] 댓글 등록시 익명 여부 POST & 댓글 조회시 익명 & 필명 나눠서 조회

### DIFF
--- a/module-domain/src/main/java/com/mile/comment/domain/Comment.java
+++ b/module-domain/src/main/java/com/mile/comment/domain/Comment.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -27,6 +28,7 @@ public class Comment extends BaseTimeEntity {
 
     @ManyToOne
     private Post post;
+    @Setter
     private String idUrl;
     private String content;
     private boolean anonymous;
@@ -37,21 +39,15 @@ public class Comment extends BaseTimeEntity {
     public static Comment create(
             final Post post,
             final WriterName writerName,
-            final CommentCreateRequest createRequest,
-            final boolean anonymous
+            final CommentCreateRequest createRequest
     ) {
         return Comment
                 .builder()
                 .post(post)
                 .content(createRequest.content())
                 .writerName(writerName)
-                .anonymous(anonymous)
+                .anonymous(createRequest.isAnonymous())
                 .build();
     }
 
-    public void setIdUrl(
-            final String idUrl
-    ) {
-        this.idUrl = idUrl;
-    }
 }

--- a/module-domain/src/main/java/com/mile/comment/service/CommentService.java
+++ b/module-domain/src/main/java/com/mile/comment/service/CommentService.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CommentService {
 
-    private static boolean ANONYMOUS_TRUE = true;
     private final PostAuthenticateService postAuthenticateService;
     private final CommentRepository commentRepository;
     private final PostGetService postGetService;
@@ -80,7 +79,7 @@ public class CommentService {
             final WriterName writerName,
             final CommentCreateRequest commentCreateRequest
     ) {
-        return commentRepository.saveAndFlush(Comment.create(post, writerName, commentCreateRequest, ANONYMOUS_TRUE));
+        return commentRepository.saveAndFlush(Comment.create(post, writerName, commentCreateRequest));
 
     }
 

--- a/module-domain/src/main/java/com/mile/comment/service/dto/CommentResponse.java
+++ b/module-domain/src/main/java/com/mile/comment/service/dto/CommentResponse.java
@@ -19,16 +19,26 @@ public record CommentResponse(
             final boolean isWriterOfPost
     ) {
         WriterName writerName = comment.getWriterName();
-        String name = ANONYMOUS + writerName.getId().toString();
-        if (isWriterOfPost) {
-            name = AUTHOR;
-        }
         return new CommentResponse(
                 comment.getIdUrl(),
-                name,
+                getNameString(comment,writerName,isWriterOfPost),
                 writerName.getMoim().getName(),
                 comment.getContent(),
                 writerName.getId().equals(writerNameId)
         );
+    }
+
+    private static String getNameString(
+            final Comment comment,
+            final WriterName writerName,
+            final boolean isWriterOfPost
+    ) {
+        if (isWriterOfPost) {
+            return AUTHOR;
+        } else if (comment.isAnonymous()) {
+            return ANONYMOUS + writerName.getId().toString();
+        } else {
+            return writerName.getName();
+        }
     }
 }

--- a/module-domain/src/main/java/com/mile/post/service/dto/CommentCreateRequest.java
+++ b/module-domain/src/main/java/com/mile/post/service/dto/CommentCreateRequest.java
@@ -2,6 +2,7 @@ package com.mile.post.service.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record CommentCreateRequest(
@@ -9,6 +10,9 @@ public record CommentCreateRequest(
         @Schema(description = "댓글 내용", example = "댓글 내용을 입력해주세요")
         @NotBlank(message = "댓글에 내용이 없습니다.")
         @Size(max = 500, message = "댓글 최대 입력 길이(500자)를 초과하였습니다.")
-        String content
+        String content,
+
+        @NotNull(message = "익명 여부가 입력되지 않았습니다.")
+        boolean isAnonymous
 ) {
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #247 

## Key Changes 🔑
1. POST 엔드포인트 수정 > Request Body에 boolean값 추가
2. GET 엔드포인트 로직 수정 -> 엔드포인트 자체는 수정할 요소가 없어서 name 리턴하는 함수 만들어서 수정했습니다

## To Reviewers 📢
-
