### PR TITLE
#261 [feat] 글모임 정보 수정 API 구현

### DIFF
--- a/module-api/src/main/java/com/mile/controller/moim/MoimController.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimController.java
@@ -10,6 +10,7 @@ import com.mile.moim.service.dto.MoimAuthenticateResponse;
 import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimInfoResponse;
 import com.mile.moim.service.dto.MoimInvitationInfoResponse;
+import com.mile.moim.service.dto.MoimInfoModifyRequest;
 import com.mile.moim.service.dto.MoimTopicResponse;
 import com.mile.moim.service.dto.PopularWriterListResponse;
 import com.mile.moim.service.dto.TemporaryPostExistResponse;
@@ -23,6 +24,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -145,5 +147,16 @@ public class MoimController implements MoimControllerSwagger {
             @PathVariable("moimId") final String moimUrl
     ) {
         return SuccessResponse.of(SuccessMessage.IS_TEMPORARY_POST_EXIST_GET_SUCCESS, moimService.getTemporaryPost(moimId, principalHandler.getUserIdFromPrincipal()));
+    }
+
+    @Override
+    @PutMapping("/{moimId}/info")
+    public ResponseEntity<SuccessResponse> modifyMoimInformation(
+            @MoimIdPathVariable final Long moimId,
+            @RequestBody final MoimInfoModifyRequest request,
+            @PathVariable("moimId") final String moimUrl
+    ) {
+        moimService.modifyMoimInforation(moimId, principalHandler.getUserIdFromPrincipal(), request);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_INFORMATION_PUT_SUCCESS));
     }
 }

--- a/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
@@ -7,6 +7,7 @@ import com.mile.moim.service.dto.ContentListResponse;
 import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimInfoResponse;
 import com.mile.moim.service.dto.MoimInvitationInfoResponse;
+import com.mile.moim.service.dto.MoimInfoModifyRequest;
 import com.mile.moim.service.dto.MoimTopicResponse;
 import com.mile.moim.service.dto.TemporaryPostExistResponse;
 import com.mile.moim.service.dto.TopicListResponse;
@@ -205,6 +206,23 @@ public interface MoimControllerSwagger {
     ResponseEntity<SuccessResponse> joinMoim(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long moimId,
             @RequestBody final WriterMemberJoinRequest joinRequest,
+            @PathVariable("moimId") final String moimUrl
+    );
+
+    @Operation(summary = "관리자 페이지 모임 정보 수정")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode =  "204", description = "모임 정보 수정이 완료되었습니다."),
+                    @ApiResponse(responseCode = "400" ,description = "1. 소개 글은 최대 100자 이내로 작성해주세요.\n" +
+                            "2. 글모임 이름은 최대 10 글자 이내로 작성해주세요.\n"),
+                    @ApiResponse(responseCode = "401", description = "로그인 후 진행해주세요."),
+                    @ApiResponse(responseCode = "403", description = "사용자는 해당 모임의 모임장이 아닙니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
+            }
+    )
+    ResponseEntity<SuccessResponse> modifyMoimInformation(
+            @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long moimId,
+            @RequestBody final MoimInfoModifyRequest request,
             @PathVariable("moimId") final String moimUrl
     );
 }

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -62,6 +62,7 @@ public enum ErrorMessage {
      */
     USER_AUTHENTICATE_ERROR(HttpStatus.FORBIDDEN.value(), "해당 사용자는 모임에 접근 권한이 없습니다."),
     WRITER_AUTHENTICATE_ERROR(HttpStatus.FORBIDDEN.value(), "해당 사용자는 글 생성/수정/삭제 권한이 없습니다."),
+    MOIM_OWNER_AUTHENTICATION_ERROR(HttpStatus.FORBIDDEN.value(), "사용자는 해당 모임의 모임장이 아닙니다."),
     /*
     Forbidden
      */

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -35,6 +35,7 @@ public enum SuccessMessage {
     IS_TEMPORARY_POST_EXIST_GET_SUCCESS(HttpStatus.OK.value(), "임시저장 글 존재 여부 조회가 완료되었습니다."),
     MOIM_INVITE_INFO_GET_SUCCESS(HttpStatus.OK.value(), "모임의 초대 정보 조회가 완료되었습니다."),
     IS_CONFLICT_WRITER_NAME_GET_SUCCESS(HttpStatus.OK.value(), "댓글 중복 여부가 조회되었습니다."),
+    MOIM_INFORMATION_PUT_SUCCESS(HttpStatus.OK.value(), "모임 정보 수정이 완료되었습니다."),
     /*
     201 CREATED
      */

--- a/module-domain/src/main/java/com/mile/moim/domain/Moim.java
+++ b/module-domain/src/main/java/com/mile/moim/domain/Moim.java
@@ -1,6 +1,7 @@
 package com.mile.moim.domain;
 
 import com.mile.config.BaseTimeEntity;
+import com.mile.moim.service.dto.MoimInfoModifyRequest;
 import com.mile.writername.domain.WriterName;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -25,4 +26,13 @@ public class Moim extends BaseTimeEntity {
     private String information;
     private String idUrl;
     private boolean isPublic;
+
+    public void modifyMoimInfo(
+            final MoimInfoModifyRequest moimInfoModifyRequest
+    ) {
+        this.name = moimInfoModifyRequest.moimTitle();
+        this.imageUrl = moimInfoModifyRequest.imageUrl();
+        this.information = moimInfoModifyRequest.description();
+        this.isPublic = moimInfoModifyRequest.isPublic();
+    }
 }

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -9,35 +9,34 @@ import com.mile.moim.service.dto.BestMoimListResponse;
 import com.mile.moim.service.dto.ContentListResponse;
 import com.mile.moim.service.dto.MoimAuthenticateResponse;
 import com.mile.moim.service.dto.MoimCuriousPostListResponse;
+import com.mile.moim.service.dto.MoimInfoModifyRequest;
 import com.mile.moim.service.dto.MoimInfoResponse;
 import com.mile.moim.service.dto.MoimInvitationInfoResponse;
 import com.mile.moim.service.dto.MoimTopicResponse;
+import com.mile.moim.service.dto.PopularWriterListResponse;
 import com.mile.moim.service.dto.TemporaryPostExistResponse;
 import com.mile.moim.service.dto.TopicListResponse;
-import com.mile.moim.service.dto.WriterNameConflictCheckResponse;
 import com.mile.moim.service.dto.WriterMemberJoinRequest;
+import com.mile.moim.service.dto.WriterNameConflictCheckResponse;
 import com.mile.post.domain.Post;
 import com.mile.post.service.PostAuthenticateService;
+import com.mile.post.service.PostCreateService;
 import com.mile.post.service.PostDeleteService;
 import com.mile.post.service.PostGetService;
-import com.mile.post.service.PostCreateService;
 import com.mile.topic.service.TopicService;
+import com.mile.user.domain.User;
 import com.mile.user.service.UserService;
 import com.mile.utils.DateUtil;
 import com.mile.utils.SecureUrlUtil;
 import com.mile.writername.domain.WriterName;
 import com.mile.writername.service.WriterNameService;
-import com.mile.moim.service.dto.PopularWriterListResponse;
-
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -61,15 +60,16 @@ public class MoimService {
         return ContentListResponse.of(topicService.getContentsFromMoim(moimId));
     }
 
-    public WriterNameConflictCheckResponse checkConflictOfWriterName(Long moimId, String writerName){
+    public WriterNameConflictCheckResponse checkConflictOfWriterName(Long moimId, String writerName) {
         return WriterNameConflictCheckResponse.of(writerNameService.existWriterNamesByMoimAndName(findById(moimId), writerName));
     }
+
     public Long joinMoim(
             final Long moimId,
             final Long userId,
             final WriterMemberJoinRequest joinRequest
     ) {
-        return writerNameService.createWriterName(userService.findById(userId),findById(moimId),joinRequest);
+        return writerNameService.createWriterName(userService.findById(userId), findById(moimId), joinRequest);
     }
 
     public MoimInvitationInfoResponse getMoimInvitationInfo(
@@ -78,13 +78,20 @@ public class MoimService {
         return MoimInvitationInfoResponse.of(findById(moimId), writerNameService.findNumbersOfWritersByMoimId(moimId));
     }
 
-    public void authenticateUserOfMoim(
-            final Long moimId,
+    public void authenticateOwnerOfMoim(
+            final Moim moim,
             final Long userId
     ) {
-        if (!writerNameService.isUserInMoim(moimId, userId)) {
-            throw new ForbiddenException(ErrorMessage.USER_AUTHENTICATE_ERROR);
+        if (!isMoimOwnerEqualsUser(moim, userService.findById(userId))) {
+            throw new ForbiddenException(ErrorMessage.MOIM_OWNER_AUTHENTICATION_ERROR);
         }
+    }
+
+    private boolean isMoimOwnerEqualsUser(
+            final Moim moim,
+            final User user
+    ) {
+        return moim.getOwner().getWriter().equals(user);
     }
 
     public MoimAuthenticateResponse getAuthenticateUserOfMoim(
@@ -152,7 +159,7 @@ public class MoimService {
         Map<Moim, List<Post>> bestMoimAndPostMap = bestMoimsByPostNumber.stream()
                 .collect(Collectors.toMap(
                         moim -> moim,
-                        moim -> postGetService.getLatestPostsByMoim(moim)
+                        postGetService::getLatestPostsByMoim
                 ));
 
         return BestMoimListResponse.of(bestMoimAndPostMap);
@@ -164,5 +171,16 @@ public class MoimService {
     ) {
         String postId = postCreateService.getTemporaryPostExist(findById(moimId), writerNameService.findByWriterId(userId));
         return TemporaryPostExistResponse.of(!secureUrlUtil.decodeUrl(postId).equals(0L), postId);
+    }
+
+    @Transactional
+    public void modifyMoimInforation(
+            final Long moimId,
+            final Long userId,
+            final MoimInfoModifyRequest modifyRequest
+    ) {
+        Moim moim = findById(moimId);
+        moim.modifyMoimInfo(modifyRequest);
+        authenticateOwnerOfMoim(moim, userId);
     }
 }

--- a/module-domain/src/main/java/com/mile/moim/service/dto/MoimInfoModifyRequest.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/MoimInfoModifyRequest.java
@@ -1,0 +1,18 @@
+package com.mile.moim.service.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record MoimInfoModifyRequest(
+        @Max(value = 10, message = " 글모임 이름은 최대 10 글자 이내로 작성해주세요.")
+        String moimTitle,
+        @Max(value = 100, message = "글모임 이름은 최대 10 글자 이내로 작성해주세요.")
+        String description,
+
+        String imageUrl,
+
+        @NotNull(message = "입력 값이 비어있습니다.")
+        boolean isPublic
+) {
+}

--- a/module-domain/src/main/java/com/mile/moim/service/dto/MoimInfoModifyRequest.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/MoimInfoModifyRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.NotNull;
 public record MoimInfoModifyRequest(
         @Max(value = 10, message = " 글모임 이름은 최대 10 글자 이내로 작성해주세요.")
         String moimTitle,
-        @Max(value = 100, message = "글모임 이름은 최대 10 글자 이내로 작성해주세요.")
+        @Max(value = 100, message = "글모임 설명은 최대 100 글자 이내로 작성해주세요.")
         String description,
 
         String imageUrl,


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #261 

## Key Changes 🔑
1. 도메인 로직 구현
2. 기존 중복체크 API URI 변경

## To Reviewers 📢
-
