### PR TITLE
#271 [feat] 관리자페이지 멤버 삭제 

### DIFF
--- a/module-api/src/main/java/com/mile/controller/writername/WriterNameController.java
+++ b/module-api/src/main/java/com/mile/controller/writername/WriterNameController.java
@@ -1,0 +1,30 @@
+package com.mile.controller.writername;
+
+import com.mile.authentication.PrincipalHandler;
+import com.mile.dto.SuccessResponse;
+import com.mile.exception.message.SuccessMessage;
+import com.mile.writername.service.WriterNameDeleteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/writerName")
+public class WriterNameController implements WriterNameControllerSwagger{
+
+    private final WriterNameDeleteService writerNameDeleteService;
+    private final PrincipalHandler principalHandler;
+
+    @Override
+    @DeleteMapping("/{writerNameId}")
+    public ResponseEntity<SuccessResponse> deleteMember(
+            @PathVariable("writerNameId") final Long writerNameId
+    ) {
+        writerNameDeleteService.deleteWriterNameById(writerNameId, principalHandler.getUserIdFromPrincipal());
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_MEMBER_DELETE_SUCCESS));
+    }
+}

--- a/module-api/src/main/java/com/mile/controller/writername/WriterNameControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/writername/WriterNameControllerSwagger.java
@@ -18,7 +18,7 @@ public interface WriterNameControllerSwagger {
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "200", description = "멤버 삭제가 완료되었습니다."),
-                    @ApiResponse(responseCode = "404", description = "해당 모임은 존재하지 않습니다."),
+                    @ApiResponse(responseCode = "404", description = "해당 사용자는 존재하지 않습니다."),
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }

--- a/module-api/src/main/java/com/mile/controller/writername/WriterNameControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/writername/WriterNameControllerSwagger.java
@@ -1,0 +1,30 @@
+package com.mile.controller.writername;
+
+import com.mile.dto.ErrorResponse;
+import com.mile.dto.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "WriterName")
+public interface WriterNameControllerSwagger {
+
+    @Operation(summary = "관리자 페이지 멤버 삭제")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "멤버 삭제가 완료되었습니다."),
+                    @ApiResponse(responseCode = "404", description = "해당 모임은 존재하지 않습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse> deleteMember(
+            @PathVariable("writerNameId") final Long writerNameId
+    );
+}
+

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -37,6 +37,7 @@ public enum SuccessMessage {
     IS_CONFLICT_WRITER_NAME_GET_SUCCESS(HttpStatus.OK.value(), "댓글 중복 여부가 조회되었습니다."),
     MOIM_INFORMATION_PUT_SUCCESS(HttpStatus.OK.value(), "모임 정보 수정이 완료되었습니다."),
     IS_CONFLICT_MOIM_NAME_GET_SUCCESS(HttpStatus.OK.value(), "글모임 이름 중복 확인이 완료되었습니다."),
+    MOIM_MEMBER_DELETE_SUCCESS(HttpStatus.OK.value(), "멤버 삭제가 완료되었습니다."),
     /*
     201 CREATED
      */

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameDeleteService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameDeleteService.java
@@ -1,0 +1,37 @@
+package com.mile.writername.service;
+
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.NotFoundException;
+import com.mile.moim.service.MoimService;
+import com.mile.writername.domain.WriterName;
+import com.mile.writername.repository.WriterNameRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class WriterNameDeleteService {
+
+    private final WriterNameRepository writerNameRepository;
+    private final MoimService moimService;
+
+    @Transactional
+    public void deleteWriterNameById(
+            final Long writerNameId,
+            final Long userId
+    ) {
+        WriterName writerName = findById(writerNameId);
+        moimService.authenticateOwnerOfMoim(writerName.getMoim(), userId);
+        writerNameRepository.delete(writerName);
+    }
+
+    private WriterName findById(
+            final Long writerNameId
+    ) {
+        WriterName writerName = writerNameRepository.findById(writerNameId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.WRITER_NOT_FOUND)
+        );
+        return writerName;
+    }
+}

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameDeleteService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameDeleteService.java
@@ -29,9 +29,8 @@ public class WriterNameDeleteService {
     private WriterName findById(
             final Long writerNameId
     ) {
-        WriterName writerName = writerNameRepository.findById(writerNameId).orElseThrow(
+        return writerNameRepository.findById(writerNameId).orElseThrow(
                 () -> new NotFoundException(ErrorMessage.WRITER_NOT_FOUND)
         );
-        return writerName;
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #271

## Key Changes 🔑
1. 관리자 페이지 멤버 삭제 로직을 구현했습니다!

## To Reviewers 📢
1. MoimService <-> WriterNameService 간의 순환 참조가 발생해서, 삭제 로직을 WriterNameDeleteService로 분리하였습니다.
2. 기존에 엔드포인트를 /moim/:moimId/writerName/:writerNameId로 하였는데, 모임 아이디를 받을 필요가 없어서 엔드포인트를 변경하였습니다!