### PR TITLE
#273 [feat] 모임 생성 API 구현

### DIFF
--- a/module-api/src/main/java/com/mile/controller/moim/MoimController.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimController.java
@@ -7,6 +7,8 @@ import com.mile.moim.service.MoimService;
 import com.mile.moim.service.dto.BestMoimListResponse;
 import com.mile.moim.service.dto.ContentListResponse;
 import com.mile.moim.service.dto.MoimAuthenticateResponse;
+import com.mile.moim.service.dto.MoimCreateRequest;
+import com.mile.moim.service.dto.MoimCreateResponse;
 import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimInfoResponse;
 import com.mile.moim.service.dto.MoimNameConflictCheckResponse;
@@ -47,7 +49,8 @@ public class MoimController implements MoimControllerSwagger {
             @MoimIdPathVariable final Long moimId,
             @PathVariable("moimId") final String moimUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.TOPIC_SEARCH_SUCCESS, moimService.getContentsFromMoim(moimId, principalHandler.getUserIdFromPrincipal()));
+        return SuccessResponse.of(SuccessMessage.TOPIC_SEARCH_SUCCESS,
+                moimService.getContentsFromMoim(moimId, principalHandler.getUserIdFromPrincipal()));
     }
 
 
@@ -58,9 +61,10 @@ public class MoimController implements MoimControllerSwagger {
             @RequestParam final String writerName,
             @PathVariable("moimId") final String moimUrl
     ) {
-        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.IS_CONFLICT_WRITER_NAME_GET_SUCCESS, moimService.checkConflictOfWriterName(moimId, writerName)));
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.IS_CONFLICT_WRITER_NAME_GET_SUCCESS,
+                moimService.checkConflictOfWriterName(moimId, writerName)));
     }
-    
+
     @Override
     @PostMapping("{moimId}/user")
     public ResponseEntity<SuccessResponse> joinMoim(
@@ -68,7 +72,9 @@ public class MoimController implements MoimControllerSwagger {
             @RequestBody final WriterMemberJoinRequest joinRequest,
             @PathVariable("moimId") final String moimUrl
     ) {
-        return ResponseEntity.created(URI.create(moimService.joinMoim(moimId, principalHandler.getUserIdFromPrincipal(), joinRequest).toString())).body(SuccessResponse.of(SuccessMessage.WRITER_JOIN_SUCCESS));
+        return ResponseEntity.created(URI.create(
+                        moimService.joinMoim(moimId, principalHandler.getUserIdFromPrincipal(), joinRequest).toString()))
+                .body(SuccessResponse.of(SuccessMessage.WRITER_JOIN_SUCCESS));
     }
 
     @Override
@@ -77,7 +83,8 @@ public class MoimController implements MoimControllerSwagger {
             @MoimIdPathVariable final Long moimId,
             @PathVariable("moimId") final String moimUrl
     ) {
-        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_INVITE_INFO_GET_SUCCESS, moimService.getMoimInvitationInfo(moimId)));
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_INVITE_INFO_GET_SUCCESS,
+                moimService.getMoimInvitationInfo(moimId)));
     }
 
     @Override
@@ -86,7 +93,8 @@ public class MoimController implements MoimControllerSwagger {
             @MoimIdPathVariable final Long moimId,
             @PathVariable("moimId") final String moimUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.MOIM_AUTHENTICATE_SUCCESS, moimService.getAuthenticateUserOfMoim(moimId, principalHandler.getUserIdFromPrincipal()));
+        return SuccessResponse.of(SuccessMessage.MOIM_AUTHENTICATE_SUCCESS,
+                moimService.getAuthenticateUserOfMoim(moimId, principalHandler.getUserIdFromPrincipal()));
     }
 
     @Override
@@ -95,7 +103,9 @@ public class MoimController implements MoimControllerSwagger {
             @MoimIdPathVariable final Long moimId,
             @PathVariable("moimId") final String moimUrl
     ) {
-        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.of(SuccessMessage.MOIM_POPULAR_WRITER_SEARCH_SUCCESS, moimService.getMostCuriousWritersOfMoim(moimId)));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.of(SuccessMessage.MOIM_POPULAR_WRITER_SEARCH_SUCCESS,
+                        moimService.getMostCuriousWritersOfMoim(moimId)));
     }
 
     @Override
@@ -124,7 +134,8 @@ public class MoimController implements MoimControllerSwagger {
             @MoimIdPathVariable final Long moimId,
             @PathVariable("moimId") final String moimUrl
     ) {
-        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.of(SuccessMessage.TOPIC_LIST_SEARCH_SUCCESS, moimService.getTopicList(moimId)));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.of(SuccessMessage.TOPIC_LIST_SEARCH_SUCCESS, moimService.getTopicList(moimId)));
     }
 
     @Override
@@ -133,12 +144,14 @@ public class MoimController implements MoimControllerSwagger {
             @MoimIdPathVariable final Long moimId,
             @PathVariable("moimId") final String moimUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.MOIM_TOP_2_POST_GET_SUCCESS, moimService.getMostCuriousPostFromMoim(moimId));
+        return SuccessResponse.of(SuccessMessage.MOIM_TOP_2_POST_GET_SUCCESS,
+                moimService.getMostCuriousPostFromMoim(moimId));
     }
 
     @GetMapping("/best")
     public ResponseEntity<SuccessResponse<BestMoimListResponse>> getBestMoimAndPostList() {
-        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.of(SuccessMessage.BEST_MOIM_POSTS_GET_SUCCESS, moimService.getBestMoimAndPostList()));
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.of(SuccessMessage.BEST_MOIM_POSTS_GET_SUCCESS,
+                moimService.getBestMoimAndPostList()));
     }
 
     @Override
@@ -147,8 +160,10 @@ public class MoimController implements MoimControllerSwagger {
             @MoimIdPathVariable final Long moimId,
             @PathVariable("moimId") final String moimUrl
     ) {
-        return SuccessResponse.of(SuccessMessage.IS_TEMPORARY_POST_EXIST_GET_SUCCESS, moimService.getTemporaryPost(moimId, principalHandler.getUserIdFromPrincipal()));
+        return SuccessResponse.of(SuccessMessage.IS_TEMPORARY_POST_EXIST_GET_SUCCESS,
+                moimService.getTemporaryPost(moimId, principalHandler.getUserIdFromPrincipal()));
     }
+
     @Override
     @PutMapping("/{moimId}/info")
     public ResponseEntity<SuccessResponse> modifyMoimInformation(
@@ -159,11 +174,21 @@ public class MoimController implements MoimControllerSwagger {
         moimService.modifyMoimInforation(moimId, principalHandler.getUserIdFromPrincipal(), request);
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_INFORMATION_PUT_SUCCESS));
     }
+
     @GetMapping("/name/validation")
     @Override
     public ResponseEntity<SuccessResponse<MoimNameConflictCheckResponse>> validateMoimName(
             @RequestParam final String moimName
     ) {
-        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.IS_CONFLICT_MOIM_NAME_GET_SUCCESS, moimService.validateMoimName(moimName)));
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.IS_CONFLICT_MOIM_NAME_GET_SUCCESS,
+                moimService.validateMoimName(moimName)));
+    }
+
+    @PostMapping
+    @Override
+    public ResponseEntity<SuccessResponse<MoimCreateResponse>> createMoim(
+            @RequestBody final MoimCreateRequest creatRequest
+    ) {
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_CREATE_SUCCESS, moimService.createMoim(principalHandler.getUserIdFromPrincipal(), creatRequest)));
     }
 }

--- a/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
@@ -4,6 +4,8 @@ import com.mile.dto.ErrorResponse;
 import com.mile.dto.SuccessResponse;
 import com.mile.moim.service.dto.BestMoimListResponse;
 import com.mile.moim.service.dto.ContentListResponse;
+import com.mile.moim.service.dto.MoimCreateRequest;
+import com.mile.moim.service.dto.MoimCreateResponse;
 import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimInfoResponse;
 import com.mile.moim.service.dto.MoimNameConflictCheckResponse;
@@ -238,5 +240,21 @@ public interface MoimControllerSwagger {
     )
     ResponseEntity<SuccessResponse<MoimNameConflictCheckResponse>> validateMoimName(
             @RequestParam final String moimName
+    );
+
+    @Operation(summary = "글모임 생성")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "201", description = "글감 리스트 조회가 완료되었습니다."),
+                    @ApiResponse(responseCode = "400" ,description = "1. 글모임명은 최대 10글자 이내로 작성해주세요.\n" +
+                            "2. 필명은 최대 8글자 이내로 작성해주세요.\n" +
+                            "3. 글모임장 소개글은 최대 100자 이내로 작성해주세요." +
+                            "4. 글감 소개글은 최대 90자 이내로 작성해주세요."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse<MoimCreateResponse>> createMoim(
+            @RequestBody final MoimCreateRequest creatRequest
     );
 }

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -47,6 +47,7 @@ public enum SuccessMessage {
     POST_CREATE_SUCCESS(HttpStatus.OK.value(), "글 생성이 완료되었습니다."),
     TEMPORARY_POST_CREATE_SUCCESS(HttpStatus.OK.value(), "임시저장 글 생성이 완료되었습니다."),
     MOIM_CREATE_SUCCESS(HttpStatus.OK.value(), "글모임 생성이 완료되었습니다."),
+    TOPIC_CREATE_SUCCESS(HttpStatus.CREATED.value(), "글감 생성이 완료되었습니다."),
     ;
 
     final int status;

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -46,6 +46,7 @@ public enum SuccessMessage {
     CURIOUS_CREATE_SUCCESS(HttpStatus.CREATED.value(), "궁금해요 생성이 완료되었습니다."),
     POST_CREATE_SUCCESS(HttpStatus.OK.value(), "글 생성이 완료되었습니다."),
     TEMPORARY_POST_CREATE_SUCCESS(HttpStatus.OK.value(), "임시저장 글 생성이 완료되었습니다."),
+    MOIM_CREATE_SUCCESS(HttpStatus.OK.value(), "글모임 생성이 완료되었습니다."),
     ;
 
     final int status;

--- a/module-domain/src/main/java/com/mile/moim/domain/Moim.java
+++ b/module-domain/src/main/java/com/mile/moim/domain/Moim.java
@@ -33,6 +33,8 @@ public class Moim extends BaseTimeEntity {
     @Setter
     private String idUrl;
     private boolean isPublic;
+    @Setter
+    private String invitationCode;
 
     public void modifyMoimInfo(
             final MoimInfoModifyRequest moimInfoModifyRequest

--- a/module-domain/src/main/java/com/mile/moim/domain/Moim.java
+++ b/module-domain/src/main/java/com/mile/moim/domain/Moim.java
@@ -1,6 +1,7 @@
 package com.mile.moim.domain;
 
 import com.mile.config.BaseTimeEntity;
+import com.mile.moim.service.dto.MoimCreateRequest;
 import com.mile.moim.service.dto.MoimInfoModifyRequest;
 import com.mile.writername.domain.WriterName;
 import jakarta.persistence.Column;
@@ -10,20 +11,26 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Moim extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     private WriterName owner;
     private String name;
     private String imageUrl;
     @Column(length = 500)
     private String information;
+    @Setter
     private String idUrl;
     private boolean isPublic;
 
@@ -34,5 +41,29 @@ public class Moim extends BaseTimeEntity {
         this.imageUrl = moimInfoModifyRequest.imageUrl();
         this.information = moimInfoModifyRequest.description();
         this.isPublic = moimInfoModifyRequest.isPublic();
+    }
+
+    @Builder
+    private Moim(
+            final String name,
+            final String imageUrl,
+            final String information,
+            final boolean isPublic
+    ) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.information = information;
+        this.isPublic = isPublic;
+    }
+
+    public static Moim create(
+            final MoimCreateRequest moimCreateRequest
+    ) {
+        return Moim.builder()
+                .name(moimCreateRequest.moimName())
+                .imageUrl(moimCreateRequest.imageUrl())
+                .information(moimCreateRequest.moimDescription())
+                .isPublic(moimCreateRequest.isPublic())
+                .build();
     }
 }

--- a/module-domain/src/main/java/com/mile/moim/domain/Moim.java
+++ b/module-domain/src/main/java/com/mile/moim/domain/Moim.java
@@ -33,8 +33,6 @@ public class Moim extends BaseTimeEntity {
     @Setter
     private String idUrl;
     private boolean isPublic;
-    @Setter
-    private String invitationCode;
 
     public void modifyMoimInfo(
             final MoimInfoModifyRequest moimInfoModifyRequest

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -8,6 +8,8 @@ import com.mile.moim.repository.MoimRepository;
 import com.mile.moim.service.dto.BestMoimListResponse;
 import com.mile.moim.service.dto.ContentListResponse;
 import com.mile.moim.service.dto.MoimAuthenticateResponse;
+import com.mile.moim.service.dto.MoimCreateRequest;
+import com.mile.moim.service.dto.MoimCreateResponse;
 import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimInfoModifyRequest;
 import com.mile.moim.service.dto.MoimInfoResponse;
@@ -189,4 +191,21 @@ public class MoimService {
     ) {
         return MoimNameConflictCheckResponse.of(!moimRepository.existsByName(moimName));
     }
+
+    @Transactional
+    public MoimCreateResponse createMoim(
+            final Long userId,
+            final MoimCreateRequest createRequest
+    ) {
+        Moim moim = moimRepository.saveAndFlush(Moim.create(createRequest));
+        User user = userService.findById(userId);
+        WriterMemberJoinRequest joinRequest = WriterMemberJoinRequest.of(createRequest.writerName(), createRequest.writerNameDescription());
+        WriterName owner = writerNameService.getById(writerNameService.createWriterName(user, moim, joinRequest));
+        moim.setOwner(owner);
+        moim.setIdUrl(secureUrlUtil.encodeUrl(moim.getId()));
+        String link = "초대링크"; // 초대링크 로직 넣기
+        // Topic 생성 로직 넣기
+        return MoimCreateResponse.of(moim.getIdUrl(), link);
+    }
+
 }

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -213,10 +213,9 @@ public class MoimService {
         User user = userService.findById(userId);
 
         setMoimOwner(moim, user, createRequest);
-        String link = generateInviteLink(moim);
         setFirstTopic(moim, userId, createRequest);
 
-        return MoimCreateResponse.of(moim.getIdUrl(), link);
+        return MoimCreateResponse.of(moim.getIdUrl(), moim.getIdUrl());
     }
 
     private void setMoimOwner(
@@ -230,11 +229,6 @@ public class MoimService {
         moim.setIdUrl(secureUrlUtil.encodeUrl(moim.getId()));
     }
 
-    private String generateInviteLink(Moim moim) {
-        String inviteLink = UUID.randomUUID().toString() + moim.getIdUrl();
-        moim.setInvitationCode(inviteLink);
-        return inviteLink;
-    }
 
     private void setFirstTopic(
             final Moim moim,

--- a/module-domain/src/main/java/com/mile/moim/service/dto/MoimCreateRequest.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/MoimCreateRequest.java
@@ -1,0 +1,32 @@
+package com.mile.moim.service.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+
+public record MoimCreateRequest(
+        @Max(value = 10, message = "글모임명은 최대 10자 이내로 작성해주세요.")
+        @NotBlank(message = "글감 제목이 비어 있습니다.")
+        String moimName,
+        @Max(value = 90, message = "글모임 소개글은 90자 이내로 작성해주세요.")
+        String moimDescription,
+        @NotBlank(message = "공개 여부를 선택해 주세요.")
+        Boolean isPublic,
+        String imageUrl,
+
+        @NotBlank(message = "필명이 입력되지 않았습니다.")
+        @Max(value = 8, message = "필명은 최대 8자 이내로 작성해주세요.")
+        String writerName,
+        @Max(value = 100, message = "필명 소개글은 최대 100자 이내로 작성해주세요.")
+        String writerNameDescription,
+
+        @Max(value = 15, message = "글감은 최대 15자 이내로 작성해주세요.")
+        @NotBlank(message = "글감 제목이 비어 있습니다.")
+        String topic,
+        @Max(value = 5, message = "글감 태그는 최대 5자 이내로 작성해주세요.")
+        @NotBlank(message = "글감 태그가 비어 있습니다.")
+        String topicTag,
+        @Max(value = 90, message = "글감 소개글은 최대 90자 이내로 작성해주세요.")
+        @NotBlank(message = "글감 설명은 비어 있습니다.")
+        String topicDescription
+) {
+}

--- a/module-domain/src/main/java/com/mile/moim/service/dto/MoimCreateResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/MoimCreateResponse.java
@@ -1,0 +1,13 @@
+package com.mile.moim.service.dto;
+
+public record MoimCreateResponse(
+        String moimId,
+        String inviteCode
+) {
+    public static MoimCreateResponse of(
+            String moimId,
+            String inviteCode
+    ) {
+        return new MoimCreateResponse(moimId, inviteCode);
+    }
+}

--- a/module-domain/src/main/java/com/mile/moim/service/dto/TopicCreateRequest.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/TopicCreateRequest.java
@@ -1,0 +1,23 @@
+package com.mile.moim.service.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+public record TopicCreateRequest(
+        @Max(value = 15, message = "글감은 최대 15자 이내로 작성해주세요.")
+        @NotBlank(message = "글감 제목이 비어있습니다.")
+        String topicName,
+        @Max(value = 5, message = "글감 태그는 최대 5자 이내로 작성해주세요.")
+        @NotBlank(message = "글감 태그가 비어있습니다.")
+        String topicTag,
+        @Max(value = 5, message = "글감 설명은 최대 90자 이내로 작성해주세요.")
+        @NotBlank(message = "글감 설명은 비어있습니다.")
+        String topicDescription
+) {
+        public static TopicCreateRequest of(
+                final String topicName,
+                final String topicTag,
+                final String topicDescription
+        ) {
+                return new TopicCreateRequest(topicName, topicTag, topicDescription);
+        }
+}

--- a/module-domain/src/main/java/com/mile/moim/service/dto/WriterMemberJoinRequest.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/WriterMemberJoinRequest.java
@@ -5,11 +5,17 @@ import jakarta.validation.constraints.NotBlank;
 
 public record WriterMemberJoinRequest(
         @NotBlank(message = "필명이 입력되지 않았습니다.")
-        @Max(value = 8, message = "필명은 최대 110자 이내로 작성해주세요.")
+        @Max(value = 8, message = "필명은 최대 8자 이내로 작성해주세요.")
         String writerName,
 
         @NotBlank(message = "소개 글이 입력되지 않았습니다.")
-        @Max(value = 110, message = "소개 글은 최대 110자 이내로 작성해주세요.")
+        @Max(value = 110, message = "소개 글은 최대 100자 이내로 작성해주세요.")
         String writerDescription
 ) {
+        public static WriterMemberJoinRequest of(
+                final String writerName,
+                final String writerDescription
+        ) {
+                return new WriterMemberJoinRequest(writerName, writerDescription);
+        }
 }

--- a/module-domain/src/main/java/com/mile/topic/domain/Topic.java
+++ b/module-domain/src/main/java/com/mile/topic/domain/Topic.java
@@ -2,13 +2,18 @@ package com.mile.topic.domain;
 
 import com.mile.config.BaseTimeEntity;
 import com.mile.moim.domain.Moim;
+import com.mile.moim.service.dto.TopicCreateRequest;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
+
+
 
 @Entity
 @Getter
@@ -18,8 +23,32 @@ public class Topic extends BaseTimeEntity {
     private Long id;
     @ManyToOne(fetch = FetchType.LAZY)
     private Moim moim;
+    @Setter
     private String idUrl;
     private String keyword;
     private String content;
     private String description;
+
+    @Builder
+    private Topic(final Moim moim,
+                  final String content,
+                  final String keyword,
+                  final String description) {
+        this.moim = moim;
+        this.content = content;
+        this.keyword = keyword;
+        this.description = description;
+    }
+
+    public static Topic create(
+            final Moim moim,
+            final TopicCreateRequest topicCreateRequest
+    ) {
+        return Topic.builder()
+                .moim(moim)
+                .content(topicCreateRequest.topicName())
+                .keyword(topicCreateRequest.topicTag())
+                .description(topicCreateRequest.topicDescription())
+                .build();
+    }
 }

--- a/module-domain/src/main/java/com/mile/topic/domain/Topic.java
+++ b/module-domain/src/main/java/com/mile/topic/domain/Topic.java
@@ -11,12 +11,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Topic extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/module-domain/src/main/java/com/mile/topic/service/TopicService.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicService.java
@@ -6,6 +6,7 @@ import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.ForbiddenException;
 import com.mile.exception.model.NotFoundException;
 import com.mile.moim.domain.Moim;
+import com.mile.moim.service.dto.TopicCreateRequest;
 import com.mile.post.service.PostGetService;
 import com.mile.post.service.dto.PostListResponse;
 import com.mile.topic.domain.Topic;
@@ -18,6 +19,7 @@ import com.mile.topic.service.dto.TopicOfMoimResponse;
 import com.mile.topic.service.dto.TopicResponse;
 import com.mile.user.domain.User;
 import com.mile.user.service.UserService;
+import com.mile.utils.SecureUrlUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
 import org.springframework.stereotype.Service;
@@ -25,6 +27,7 @@ import org.springframework.stereotype.Service;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +37,7 @@ public class TopicService {
     private final CommentService commentService;
     private final UserService userService;
     private final PostGetService postGetService;
+    private final SecureUrlUtil secureUrlUtil;
 
     public List<ContentResponse> getContentsFromMoim(
             final Long moimId
@@ -143,5 +147,16 @@ public class TopicService {
         Topic topic = findById(topicId);
         authenticateTopicWithUser(topic, userService.findById(userId));
         return TopicDetailResponse.of(topic);
+    }
+
+
+    @Transactional
+    public Long createTopicOfMoim(
+            final Moim moim,
+            final TopicCreateRequest createRequest
+    ) {
+        Topic topic = topicRepository.saveAndFlush(Topic.create(moim, createRequest));
+        topic.setIdUrl(secureUrlUtil.encodeUrl(topic.getId()));
+        return topic.getId();
     }
 }

--- a/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
+++ b/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
@@ -24,5 +24,5 @@ public interface WriterNameRepository extends JpaRepository<WriterName, Long> {
     List<WriterName> findTop2ByMoimIdAndTotalCuriousCountGreaterThanOrderByTotalCuriousCountDesc(final Long moimId, final int totalCuriousCount);
     Page<WriterName> findByMoimIdOrderByIdDesc(Long moimId, Pageable pageable);
 
-    Optional<WriterName> getById(final Long id);
+    Optional<WriterName> findById(final Long id);
 }

--- a/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
+++ b/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
@@ -23,4 +23,6 @@ public interface WriterNameRepository extends JpaRepository<WriterName, Long> {
 
     List<WriterName> findTop2ByMoimIdAndTotalCuriousCountGreaterThanOrderByTotalCuriousCountDesc(final Long moimId, final int totalCuriousCount);
     Page<WriterName> findByMoimIdOrderByIdDesc(Long moimId, Pageable pageable);
+
+    Optional<WriterName> getById(final Long id);
 }

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -107,4 +107,8 @@ public class WriterNameService {
         writerNameRepository.saveAndFlush(writerName);
         return writerName.getId();
     }
+
+    public WriterName getById(final Long writerNameId) {
+        return writerNameRepository.getById(writerNameId);
+    }
 }

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -117,7 +117,10 @@ public class WriterNameService {
     }
 
     public WriterName getById(final Long writerNameId) {
-        return writerNameRepository.getById(writerNameId);
+        return writerNameRepository.getById(writerNameId)
+                .orElseThrow(
+                () -> new NotFoundException(ErrorMessage.WRITER_NOT_FOUND)
+        );
     }
 
     private List<WriterName> findAllByMoimId(

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -117,7 +117,7 @@ public class WriterNameService {
     }
 
     public WriterName getById(final Long writerNameId) {
-        return writerNameRepository.getById(writerNameId)
+        return writerNameRepository.findById(writerNameId)
                 .orElseThrow(
                 () -> new NotFoundException(ErrorMessage.WRITER_NOT_FOUND)
         );


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #273

## Key Changes 🔑
모임 생성 API를 구현하였습니다.

## To Reviewers 📢

1. Request를 바탕으로 모임을 우선 생성하고,
2. 모임을 생성한 유저와 생성된 모임을 바탕으로 운영자 필명 생성
3. 초대링크 생성
4. 첫 글감 생성

의 순서로 로직을 구현하였습니다!
