### PR TITLE
#270 [feat] 관리자페이지 글감 삭제 구현

### DIFF
--- a/module-api/src/main/java/com/mile/controller/topic/TopicController.java
+++ b/module-api/src/main/java/com/mile/controller/topic/TopicController.java
@@ -12,8 +12,10 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -41,5 +43,15 @@ public class TopicController implements TopicControllerSwagger {
             @PathVariable("topicId") final String topicUrl
     ) {
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.TOPIC_DETAIL_GET_SUCCESS ,topicService.getTopicDetail(principalHandler.getUserIdFromPrincipal(), topicId)));
+    }
+
+    @Override
+    @DeleteMapping("/{topicId}")
+    public ResponseEntity<SuccessResponse> deleteTopic(
+            @TopicIdPathVariable final Long topicId,
+            @PathVariable("topicId") final String topicUrl
+    ) {
+        topicService.deleteTopic(principalHandler.getUserIdFromPrincipal(), topicId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.TOPIC_DELETE_SUCCESS));
     }
 }

--- a/module-api/src/main/java/com/mile/controller/topic/TopicControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/topic/TopicControllerSwagger.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Topic")
 public interface TopicControllerSwagger {
@@ -51,6 +52,22 @@ public interface TopicControllerSwagger {
             }
     )
     ResponseEntity<SuccessResponse<TopicDetailResponse>> getTopicDetail(
+            @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long topicId,
+            @PathVariable("topicId") final String topicUrl
+    );
+
+    @Operation(summary = "글감 삭제")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "글감 삭제가 완료되었습니다."),
+                    @ApiResponse(responseCode = "403", description = "1. 사용자는 해당 모임의 모임장이 아닙니다./n" +
+                            "2. 모임에는 최소 하나의 글감이 있어야 합니다."),
+                    @ApiResponse(responseCode = "404", description = "해당 글감은 존재하지 않습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse> deleteTopic(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long topicId,
             @PathVariable("topicId") final String topicUrl
     );

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -45,6 +45,7 @@ public enum ErrorMessage {
     IMAGE_EXTENSION_INVALID_ERROR(HttpStatus.BAD_REQUEST.value(), "이미지 확장자는 jpg, png, webp만 가능합니다."),
     IMAGE_SIZE_INVALID_ERROR(HttpStatus.BAD_REQUEST.value(), "이미지 사이즈는 5MB를 넘을 수 없습니다."),
     INVALID_URL_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "요청된 URL을 다시 확인해주세요"),
+    LEAST_TOPIC_SIZE_OF_MOIM_ERROR(HttpStatus.BAD_REQUEST.value(), "모임에는 최소 하나의 글감이 있어야 합니다."),
     /*
     Conflict
      */
@@ -80,6 +81,7 @@ public enum ErrorMessage {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류입니다."),
     DISCORD_LOG_APPENDER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "디스코드 로그 전송에 실패하였습니다"),
     ;
+
     final int status;
     final String message;
 }

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -40,6 +40,7 @@ public enum SuccessMessage {
     IS_CONFLICT_MOIM_NAME_GET_SUCCESS(HttpStatus.OK.value(), "글모임 이름 중복 확인이 완료되었습니다."),
     TOPIC_CREATE_SUCCESS(HttpStatus.CREATED.value(), "글감 생성이 완료되었습니다."),
     MOIM_INFO_FOR_OWNER_GET_SUCCESS(HttpStatus.OK.value(), "관리자 페이지의 모임 정보가 조회되었습니다."),
+    TOPIC_DELETE_SUCCESS(HttpStatus.OK.value(), "글감 삭제가 완료되었습니다."),
     /*
     201 CREATED
      */

--- a/module-domain/src/main/java/com/mile/post/service/PostDeleteService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostDeleteService.java
@@ -8,6 +8,7 @@ import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimMostCuriousPostResponse;
 import com.mile.post.domain.Post;
 import com.mile.post.repository.PostRepository;
+import com.mile.writername.domain.WriterName;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -35,12 +36,17 @@ public class PostDeleteService {
         deleteRelatedData(post);
         postRepository.delete(post);
     }
+
     private void deleteRelatedData(
             final Post post
     ) {
         if (post.isContainPhoto()) {
             deleteS3File(post.getImageUrl());
         }
+
+        WriterName writerName = post.getWriterName();
+        writerName.decreaseTotalCuriousCountByPostDelete(post.getCuriousCount());
+
         curiousService.deleteAllByPost(post);
         commentService.deleteAllByPost(post);
     }

--- a/module-domain/src/main/java/com/mile/post/service/PostGetService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostGetService.java
@@ -42,4 +42,10 @@ public class PostGetService {
     public List<Post> getLatestPostsByMoim(Moim moim) {
         return postRepository.findLatest4NonTemporaryPostsByMoim(moim);
     }
+
+    public List<Post> findAllByTopic(
+            final Topic topic
+    ) {
+        return postRepository.findByTopic(topic);
+    }
 }

--- a/module-domain/src/main/java/com/mile/topic/repository/TopicRepository.java
+++ b/module-domain/src/main/java/com/mile/topic/repository/TopicRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface TopicRepository extends JpaRepository<Topic, Long>, TopicRepositoryCustom {
 
     List<Topic> findByMoimId(final Long moimId);
+    Long countByMoimId(final Long moimId);
+
 }

--- a/module-domain/src/main/java/com/mile/topic/service/TopicService.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicService.java
@@ -173,17 +173,16 @@ public class TopicService {
         User user = userService.findById(userId);
         authenticateTopicWithUser(topic, user);
 
-        preventSingleTopicDeletion(topic);
+        checkSingleTopicDeletion(topic);
 
         deletePostsOfTopic(topic);
         topicRepository.deleteById(topic.getId());
     }
 
-    private void preventSingleTopicDeletion(
+    private void checkSingleTopicDeletion(
             final Topic topic
     ) {
-        Long topicCount = topicRepository.countByMoimId(topic.getMoim().getId());
-        if (topicCount <= 1) {
+        if (topicRepository.countByMoimId(topic.getMoim().getId()) <= 1) {
             throw new BadRequestException(ErrorMessage.LEAST_TOPIC_SIZE_OF_MOIM_ERROR);
         }
     }
@@ -191,9 +190,7 @@ public class TopicService {
     private void deletePostsOfTopic(
         final Topic topic
     ) {
-        List<Post> posts = postGetService.findAllByTopic(topic);
-        for (Post post: posts) {
-            postDeleteService.delete(post);
-        }
+        postGetService.findAllByTopic(topic)
+                .forEach(postDeleteService::delete);
     }
 }

--- a/module-domain/src/main/java/com/mile/topic/service/TopicService.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicService.java
@@ -2,11 +2,16 @@ package com.mile.topic.service;
 
 import com.mile.comment.service.CommentService;
 import com.mile.config.BaseTimeEntity;
+import com.mile.curious.service.CuriousService;
 import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.BadRequestException;
 import com.mile.exception.model.ForbiddenException;
+import com.mile.exception.model.MileException;
 import com.mile.exception.model.NotFoundException;
 import com.mile.moim.domain.Moim;
 import com.mile.moim.service.dto.TopicCreateRequest;
+import com.mile.post.domain.Post;
+import com.mile.post.service.PostDeleteService;
 import com.mile.post.service.PostGetService;
 import com.mile.post.service.dto.PostListResponse;
 import com.mile.topic.domain.Topic;
@@ -22,7 +27,6 @@ import com.mile.user.service.UserService;
 import com.mile.utils.SecureUrlUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
@@ -38,6 +42,7 @@ public class TopicService {
     private final UserService userService;
     private final PostGetService postGetService;
     private final SecureUrlUtil secureUrlUtil;
+    private final PostDeleteService postDeleteService;
 
     public List<ContentResponse> getContentsFromMoim(
             final Long moimId
@@ -157,5 +162,38 @@ public class TopicService {
         Topic topic = topicRepository.saveAndFlush(Topic.create(moim, createRequest));
         topic.setIdUrl(secureUrlUtil.encodeUrl(topic.getId()));
         return topic.getId();
+    }
+
+    @Transactional
+    public void deleteTopic(
+            final Long userId,
+            final Long topicId
+    ) {
+        Topic topic = findById(topicId);
+        User user = userService.findById(userId);
+        authenticateTopicWithUser(topic, user);
+
+        preventSingleTopicDeletion(topic);
+
+        deletePostsOfTopic(topic);
+        topicRepository.deleteById(topic.getId());
+    }
+
+    private void preventSingleTopicDeletion(
+            final Topic topic
+    ) {
+        Long topicCount = topicRepository.countByMoimId(topic.getMoim().getId());
+        if (topicCount <= 1) {
+            throw new BadRequestException(ErrorMessage.LEAST_TOPIC_SIZE_OF_MOIM_ERROR);
+        }
+    }
+
+    private void deletePostsOfTopic(
+        final Topic topic
+    ) {
+        List<Post> posts = postGetService.findAllByTopic(topic);
+        for (Post post: posts) {
+            postDeleteService.delete(post);
+        }
     }
 }

--- a/module-domain/src/main/java/com/mile/writername/domain/WriterName.java
+++ b/module-domain/src/main/java/com/mile/writername/domain/WriterName.java
@@ -47,6 +47,11 @@ public class WriterName {
         }
     }
 
+    public void decreaseTotalCuriousCountByPostDelete(Integer count) {
+        this.totalCuriousCount -= count;
+        setTotalCuriousCountZero();
+    }
+
     @Builder
     private WriterName(
             final Moim moim,

--- a/module-domain/src/main/java/com/mile/writername/domain/WriterName.java
+++ b/module-domain/src/main/java/com/mile/writername/domain/WriterName.java
@@ -38,18 +38,18 @@ public class WriterName {
 
     public void decreaseTotalCuriousCount() {
         totalCuriousCount--;
-        setTotalCuriousCountZero();
+        validateTotalCuriousCount();
     }
 
-    private void setTotalCuriousCountZero() {
+    private void validateTotalCuriousCount() {
         if( this.totalCuriousCount < 0 ) {
             this.totalCuriousCount = 0;
         }
     }
 
-    public void decreaseTotalCuriousCountByPostDelete(Integer count) {
+    public void decreaseTotalCuriousCountByPostDelete(final int count) {
         this.totalCuriousCount -= count;
-        setTotalCuriousCountZero();
+        validateTotalCuriousCount();
     }
 
     @Builder


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #270

## Key Changes 🔑
1. 글감 삭제 로직을 구현하였습니다!
2. 글 삭제 버그를 발견하여 수정했습니다.
- 글 삭제를 할 때, 해당 글에 대한 '궁금해요'들도 삭제됩니다.
- '궁금해요'들을 삭제하면서, 해당 글을 작성한 작가의 궁금해요수(totalCuriousCount) 도 감소시켜주어야 하는데, 해당 로직이 빠져 있어 추가했습니다.
```java
    private void deleteRelatedData(
            final Post post
    ) {
        if (post.isContainPhoto()) {
            deleteS3File(post.getImageUrl());
        }

         // 추가한 부분
        WriterName writerName = post.getWriterName();
        writerName.decreaseTotalCuriousCountByPostDelete(post.getCuriousCount());

        curiousService.deleteAllByPost(post);
        commentService.deleteAllByPost(post);
    }
```
## To Reviewers 📢
글감 삭제 로직은
1. 글감이 하나 남아있는 경우 예외처리
2. 글감에 대한 삭제 시 해당 글감의 글 삭제
- 글을 작성한 작가의 궁금해요 개수 차감
- 글에 대한 궁금해요 삭제
- 글에 대한 댓글 삭제
로 이뤄집니다!

