### PR TITLE
#286 [feat] 임시저장 글 생성 시 삭제 로직 반영

### DIFF
--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -12,9 +12,9 @@ import com.mile.moim.service.dto.MoimCuriousPostListResponse;
 import com.mile.moim.service.dto.MoimInfoModifyRequest;
 import com.mile.moim.service.dto.MoimInfoOwnerResponse;
 import com.mile.moim.service.dto.MoimInfoResponse;
-import com.mile.moim.service.dto.MoimTopicInfoListResponse;
-import com.mile.moim.service.dto.MoimNameConflictCheckResponse;
 import com.mile.moim.service.dto.MoimInvitationInfoResponse;
+import com.mile.moim.service.dto.MoimNameConflictCheckResponse;
+import com.mile.moim.service.dto.MoimTopicInfoListResponse;
 import com.mile.moim.service.dto.MoimTopicResponse;
 import com.mile.moim.service.dto.MoimWriterNameListGetResponse;
 import com.mile.moim.service.dto.PopularWriterListResponse;
@@ -35,9 +35,6 @@ import com.mile.utils.DateUtil;
 import com.mile.utils.SecureUrlUtil;
 import com.mile.writername.domain.WriterName;
 import com.mile.writername.service.WriterNameService;
-import com.mile.moim.service.dto.PopularWriterListResponse;
-import java.util.stream.Collectors;
-import com.mile.writername.service.dto.WriterNameInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -177,14 +174,14 @@ public class MoimService {
             final Long moimId,
             final Long userId
     ) {
-        String postId = postCreateService.getTemporaryPostExist(findById(moimId), writerNameService.findByWriterId(userId));
+        String postId = postGetService.getTemporaryPostExist(findById(moimId), writerNameService.findByWriterId(userId));
         return TemporaryPostExistResponse.of(!secureUrlUtil.decodeUrl(postId).equals(0L), postId);
     }
 
     public MoimTopicInfoListResponse getMoimTopicList(
-        final Long moimId,
-        final Long userId,
-        final int page
+            final Long moimId,
+            final Long userId,
+            final int page
     ) {
         getAuthenticateOwnerOfMoim(moimId, userId);
         return topicService.getTopicListFromMoim(moimId, page);
@@ -211,6 +208,7 @@ public class MoimService {
         moim.modifyMoimInfo(modifyRequest);
         authenticateOwnerOfMoim(moim, userId);
     }
+
     public MoimNameConflictCheckResponse validateMoimName(
             final String moimName
     ) {
@@ -227,6 +225,7 @@ public class MoimService {
         authenticateOwnerOfMoim(moim, userId);
         return topicService.createTopicOfMoim(moim, createRequest).toString();
     }
+
     public MoimInfoOwnerResponse getMoimInfoForOwner(
             final Long moimId,
             final Long userId

--- a/module-domain/src/main/java/com/mile/post/service/PostDeleteService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostDeleteService.java
@@ -23,11 +23,19 @@ public class PostDeleteService {
     private final CuriousService curiousService;
     private final CommentService commentService;
     private final S3Service s3Service;
+
     private List<Post> getPostHaveCuriousCount(
             final List<Post> postList
     ) {
         postList.removeIf(post -> post.getCuriousCount() <= 0);
         return postList;
+    }
+
+    public void deleteTemporaryPosts(
+            final Moim moim,
+            final WriterName writerName
+    ) {
+        postRepository.findByMoimAndWriterNameWhereIsTemporary(moim, writerName).forEach(this::delete);
     }
 
     public void delete(
@@ -56,6 +64,7 @@ public class PostDeleteService {
     ) {
         s3Service.deleteImage(key);
     }
+
     public MoimCuriousPostListResponse getMostCuriousPostByMoim(final Moim moim) {
         List<Post> postList = getPostHaveCuriousCount(postRepository.findTop2ByMoimOrderByCuriousCountDesc(moim));
         return MoimCuriousPostListResponse.of(postList

--- a/module-domain/src/main/java/com/mile/post/service/PostGetService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostGetService.java
@@ -7,6 +7,8 @@ import com.mile.moim.domain.Moim;
 import com.mile.post.domain.Post;
 import com.mile.post.repository.PostRepository;
 import com.mile.topic.domain.Topic;
+import com.mile.utils.SecureUrlUtil;
+import com.mile.writername.domain.WriterName;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,7 +21,7 @@ import java.util.stream.Collectors;
 public class PostGetService {
 
     private final PostRepository postRepository;
-
+    private final SecureUrlUtil secureUrlUtil;
 
     public Post findById(
             final Long postId
@@ -27,6 +29,25 @@ public class PostGetService {
         return postRepository.findById(postId).orElseThrow(
                 () -> new NotFoundException(ErrorMessage.POST_NOT_FOUND)
         );
+
+    }
+
+
+    public String getTemporaryPostExist(
+            final Moim moim,
+            final WriterName writerName
+    ) {
+        List<Post> postList = postRepository.findByMoimAndWriterNameWhereIsTemporary(moim, writerName);
+        if (isPostListEmpty(postList)) {
+            return secureUrlUtil.encodeUrl(0L);
+        }
+        return postList.stream().sorted(Comparator.comparing(Post::getCreatedAt).reversed()).toList().get(0).getIdUrl();
+    }
+
+    private boolean isPostListEmpty(
+            final List<Post> postList
+    ) {
+        return postList.isEmpty();
     }
 
     public List<Post> findByTopic(

--- a/module-domain/src/main/java/com/mile/post/service/PostGetService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostGetService.java
@@ -41,7 +41,8 @@ public class PostGetService {
         if (isPostListEmpty(postList)) {
             return secureUrlUtil.encodeUrl(0L);
         }
-        return postList.stream().sorted(Comparator.comparing(Post::getCreatedAt).reversed()).toList().get(0).getIdUrl();
+        postList.sort(Comparator.comparing(Post::getCreatedAt).reversed());
+        return postList.get(0).getIdUrl();
     }
 
     private boolean isPostListEmpty(


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #286 

## Key Changes 🔑
1. 기존에 흩어져 있던 post 관련 책임을 분리하였습니다.
2. 모임과 사용자에 해당하는 임시 저장 글이 있을 시 삭제하는 로직을 구현했습니다.

## To Reviewers 📢
-
