### PR TITLE
#290 [feat] 멤버 리스트 조회 변경 사항 반영

### DIFF
--- a/module-domain/src/main/java/com/mile/comment/repository/CommentRepository.java
+++ b/module-domain/src/main/java/com/mile/comment/repository/CommentRepository.java
@@ -19,4 +19,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Modifying
     @Query("delete from Comment c where c.post = :post")
     void deleteAllByPost(@Param("post")final Post post);
+
+    int countByWriterNameId(final Long writerNameId);
 }

--- a/module-domain/src/main/java/com/mile/comment/service/CommentGetService.java
+++ b/module-domain/src/main/java/com/mile/comment/service/CommentGetService.java
@@ -1,0 +1,18 @@
+package com.mile.comment.service;
+
+import com.mile.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentGetService {
+
+    private final CommentRepository commentRepository;
+
+    public int findCommentCountByWriterNameId(
+            final Long writerNameId
+    ) {
+        return commentRepository.countByWriterNameId(writerNameId);
+    }
+}

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepository.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
     boolean existsPostByIdAndWriterNameId(final Long postId, final Long userId);
     List<Post> findByTopic(final Topic topic);
-
+    int countByWriterNameId(final Long writerNameId);
 }

--- a/module-domain/src/main/java/com/mile/post/service/PostGetService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostGetService.java
@@ -48,4 +48,11 @@ public class PostGetService {
     ) {
         return postRepository.findByTopic(topic);
     }
+
+    public int findPostCountByWriterNameId(
+            final Long writerNameId
+    ) {
+        return postRepository.countByWriterNameId(writerNameId);
+    }
+
 }

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -1,11 +1,14 @@
 package com.mile.writername.service;
 
+import com.mile.comment.service.CommentGetService;
+import com.mile.comment.service.CommentService;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.NotFoundException;
 import com.mile.moim.domain.Moim;
 import com.mile.moim.service.dto.MoimWriterNameListGetResponse;
 import com.mile.moim.service.dto.WriterMemberJoinRequest;
 import com.mile.post.domain.Post;
+import com.mile.post.service.PostGetService;
 import com.mile.user.domain.User;
 import com.mile.writername.domain.WriterName;
 import com.mile.writername.repository.WriterNameRepository;
@@ -25,6 +28,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WriterNameService {
     private final WriterNameRepository writerNameRepository;
+    private final PostGetService postGetService;
+    private final CommentGetService commentGetService;
     private static final int MIN_TOTAL_CURIOUS_COUNT = 0;
     private static final int WRITERNAME_PER_PAGE_SIZE = 5;
 
@@ -137,7 +142,9 @@ public class WriterNameService {
         Page<WriterName> writerNamePage = writerNameRepository.findByMoimIdOrderByIdDesc(moimId, pageRequest);
         List<WriterNameInfoResponse> infoResponses = writerNamePage.getContent()
                 .stream()
-                .map(writerName -> WriterNameInfoResponse.of(writerName.getId(), writerName.getName(), writerName.getInformation()))
+                .map(writerName -> WriterNameInfoResponse.of(writerName.getId(), writerName.getName(),
+                        postGetService.findPostCountByWriterNameId(writerName.getId()),
+                        commentGetService.findCommentCountByWriterNameId(writerName.getId())))
                 .collect(Collectors.toList());
 
         return MoimWriterNameListGetResponse.of(

--- a/module-domain/src/main/java/com/mile/writername/service/dto/WriterNameInfoResponse.java
+++ b/module-domain/src/main/java/com/mile/writername/service/dto/WriterNameInfoResponse.java
@@ -3,13 +3,15 @@ package com.mile.writername.service.dto;
 public record WriterNameInfoResponse(
         Long writerNameId,
         String writerName,
-        String information
+        int postCount,
+        int commentCount
 ) {
     public static WriterNameInfoResponse of(
             final Long writerNameId,
             final String writerName,
-            final String information
+            final int postCount,
+            final int commentCount
     ) {
-        return new WriterNameInfoResponse(writerNameId, writerName, information);
+        return new WriterNameInfoResponse(writerNameId, writerName, postCount, commentCount);
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #290 

## Key Changes 🔑
1. 내용
멤버 리스트 조회에서, 멤버의 게시물 수와 댓글 수를 리턴하는 것으로 변경되어서 해당 부분을 구현했습니다

## To Reviewers 📢
- writerNameService와 commentService간 순환참조 문제가 발생하여 commentGetService로 댓글 개수 조회 메서드를 분리하였습니다
