### PR TITLE
#283 [refactor] 비공개 모임에 대한 조회 로직 수정

### DIFF
--- a/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
+++ b/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
@@ -2,10 +2,18 @@ package com.mile.moim.repository;
 
 import com.mile.moim.domain.Moim;
 import com.mile.post.domain.Post;
+import org.springframework.data.domain.Pageable;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MoimRepository extends JpaRepository<Moim, Long>, MoimRepositoryCustom {
     List<Post> getPostsById(final Long id);
     Boolean existsByName(final String name);
+
+    @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true AND p.createdAt BETWEEN :startOfWeek AND :endOfWeek GROUP BY m ORDER BY COUNT(p) DESC")
+    List<Moim> findTop3PrivateMoimsWithMostPostsLastWeek(Pageable pageable, @Param("startOfWeek") LocalDateTime startOfWeek, @Param("endOfWeek") LocalDateTime endOfWeek);
+
 }

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -160,7 +160,7 @@ public class MoimService {
     public List<Moim> getBestMoimByPostNumber() {
         LocalDateTime endOfWeek = LocalDateTime.now();
         LocalDateTime startOfWeek = endOfWeek.minusDays(7);
-        PageRequest pageRequest = PageRequest.of(0, 3); // Top 3
+        PageRequest pageRequest = PageRequest.of(0, 2);
         List<Moim> moims = moimRepository.findTop3PrivateMoimsWithMostPostsLastWeek(pageRequest, startOfWeek, endOfWeek);
         System.out.println(moims);
         return moims;

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -35,10 +35,10 @@ import com.mile.utils.DateUtil;
 import com.mile.utils.SecureUrlUtil;
 import com.mile.writername.domain.WriterName;
 import com.mile.writername.service.WriterNameService;
-import com.mile.moim.service.dto.PopularWriterListResponse;
+import java.time.LocalDateTime;
 import java.util.stream.Collectors;
-import com.mile.writername.service.dto.WriterNameInfoResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -156,7 +156,11 @@ public class MoimService {
     }
 
     public List<Moim> getBestMoimByPostNumber() {
-        List<Moim> moims = moimRepository.findTop3MoimsByPostCountInLastWeek();
+        LocalDateTime endOfWeek = LocalDateTime.now();
+        LocalDateTime startOfWeek = endOfWeek.minusDays(7);
+        PageRequest pageRequest = PageRequest.of(0, 3); // Top 3
+        List<Moim> moims = moimRepository.findTop3PrivateMoimsWithMostPostsLastWeek(pageRequest, startOfWeek, endOfWeek);
+        System.out.println(moims);
         return moims;
     }
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #283

## Key Changes 🔑
1. 내용
기존 로직에서 비공개 모임에 대한 조회 로직을 반영하지 않고 있어서, 해당 부분을 추가했습니다.
베스트 모임 조회에서 최신 1주일 기준 가장 많은 글이 생성된 비공개 모임의 top 3를 반환했습니다.
```java
    @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true AND p.createdAt BETWEEN :startOfWeek AND :endOfWeek GROUP BY m ORDER BY COUNT(p) DESC")
    List<Moim> findTop3PrivateMoimsWithMostPostsLastWeek(Pageable pageable, @Param("startOfWeek") LocalDateTime startOfWeek, @Param("endOfWeek") LocalDateTime endOfWeek);

```

