### PR TITLE
#284 [refactor] 멤버 삭제 리팩토링

### DIFF
--- a/module-domain/src/main/java/com/mile/comment/repository/CommentRepository.java
+++ b/module-domain/src/main/java/com/mile/comment/repository/CommentRepository.java
@@ -19,4 +19,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Modifying
     @Query("delete from Comment c where c.post = :post")
     void deleteAllByPost(@Param("post")final Post post);
+
+    void deleteAllByWriterNameId(final Long writerNameId);
 }

--- a/module-domain/src/main/java/com/mile/comment/service/CommentService.java
+++ b/module-domain/src/main/java/com/mile/comment/service/CommentService.java
@@ -126,4 +126,10 @@ public class CommentService {
     ) {
         commentRepository.deleteAllByPost(post);
     }
+
+    public void deleteAllCommentByWriterNameId(
+            final Long writerNameId
+    ) {
+        commentRepository.deleteAllByWriterNameId(writerNameId);
+    }
 }

--- a/module-domain/src/main/java/com/mile/curious/domain/Curious.java
+++ b/module-domain/src/main/java/com/mile/curious/domain/Curious.java
@@ -11,10 +11,12 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Builder
+@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
 public class Curious extends BaseTimeEntity {

--- a/module-domain/src/main/java/com/mile/curious/repository/CuriousRepository.java
+++ b/module-domain/src/main/java/com/mile/curious/repository/CuriousRepository.java
@@ -2,6 +2,7 @@ package com.mile.curious.repository;
 import com.mile.curious.domain.Curious;
 import com.mile.post.domain.Post;
 import com.mile.user.domain.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -14,4 +15,6 @@ public interface CuriousRepository extends JpaRepository<Curious, Long> {
     @Modifying
     @Query("delete from Curious c where c.post = :post")
     void deleteAllByPost(@Param("post") final Post post);
+
+    List<Curious> findAllByUserId(final Long userId);
 }

--- a/module-domain/src/main/java/com/mile/curious/service/CuriousService.java
+++ b/module-domain/src/main/java/com/mile/curious/service/CuriousService.java
@@ -8,7 +8,9 @@ import com.mile.exception.model.ConflictException;
 import com.mile.exception.model.NotFoundException;
 import com.mile.post.domain.Post;
 import com.mile.user.domain.User;
+import com.mile.writername.domain.WriterName;
 import com.mile.writername.service.WriterNameService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -53,5 +55,21 @@ public class CuriousService {
             final Post post
     ) {
         curiousRepository.deleteAllByPost(post);
+    }
+
+    public void deleteAllByWriterNameId(
+            final Long userId
+    ) {
+        List<Curious> curiousList = curiousRepository.findAllByUserId(userId);
+
+        curiousList.forEach(curious -> {
+            Post post = curious.getPost();
+            WriterName writerName = post.getWriterName();
+
+            post.decreaseCuriousCount();
+            writerName.decreaseTotalCuriousCount();
+        });
+
+        curiousRepository.deleteAll(curiousList);
     }
 }

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepository.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
     boolean existsPostByIdAndWriterNameId(final Long postId, final Long userId);
     List<Post> findByTopic(final Topic topic);
-
+    List<Post> findByWriterNameId(final Long writerNameId);
 }

--- a/module-domain/src/main/java/com/mile/post/service/PostDeleteService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostDeleteService.java
@@ -65,4 +65,9 @@ public class PostDeleteService {
                 ).collect(Collectors.toList()));
     }
 
+
+    public void deleteAllPostByWriterNameId(final Long writerNameId) {
+        List<Post> posts = postRepository.findByWriterNameId(writerNameId);
+        posts.forEach(this::delete);
+    }
 }

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameDeleteService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameDeleteService.java
@@ -1,8 +1,11 @@
 package com.mile.writername.service;
 
+import com.mile.comment.service.CommentService;
+import com.mile.curious.service.CuriousService;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.NotFoundException;
 import com.mile.moim.service.MoimService;
+import com.mile.post.service.PostDeleteService;
 import com.mile.writername.domain.WriterName;
 import com.mile.writername.repository.WriterNameRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +17,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class WriterNameDeleteService {
 
     private final WriterNameRepository writerNameRepository;
+    private final PostDeleteService postDeleteService;
+    private final CommentService commentService;
+    private final CuriousService curiousService;
     private final MoimService moimService;
 
     @Transactional
@@ -23,6 +29,11 @@ public class WriterNameDeleteService {
     ) {
         WriterName writerName = findById(writerNameId);
         moimService.authenticateOwnerOfMoim(writerName.getMoim(), userId);
+
+        postDeleteService.deleteAllPostByWriterNameId(writerNameId);
+        commentService.deleteAllCommentByWriterNameId(writerNameId);
+        curiousService.deleteAllByWriterNameId(writerName.getWriter().getId());
+
         writerNameRepository.delete(writerName);
     }
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #284

## Key Changes 🔑
멤버 삭제 API 에서 아래 로직을 보완했습니다.

1) 멤버가 작성한 글 삭제 -> 해당 글의 연관 데이터 삭제 (궁금해요, 댓글 등)
2) 멤버가 다른 글에 작성한 댓글 삭제
3) 멤버가 다른 글에 누른 궁금해요 삭제 
-> 이 경우, 해당 글의 작가의 '총 궁금해요 수' 감소 로직과 해당 글의 '총 궁금해요 수' 감소 로직도 함께 구현했습니다.
