### PR TITLE
#296 [feat] 대댓글 관련 기능 전체 구현

### DIFF
--- a/module-api/src/main/java/com/mile/controller/comment/CommentController.java
+++ b/module-api/src/main/java/com/mile/controller/comment/CommentController.java
@@ -3,21 +3,27 @@ package com.mile.controller.comment;
 
 import com.mile.authentication.PrincipalHandler;
 import com.mile.comment.service.CommentService;
+import com.mile.commentreply.service.dto.ReplyCreateRequest;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
 import com.mile.resolver.comment.CommentIdPathVariable;
+import com.mile.resolver.reply.ReplyIdPathVariable;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Slf4j
 @RequestMapping("/api/comment")
 @RequiredArgsConstructor
-public class CommentController implements CommentControllerSwagger{
+public class CommentController implements CommentControllerSwagger {
 
     private final CommentService commentService;
     private final PrincipalHandler principalHandler;
@@ -29,5 +35,27 @@ public class CommentController implements CommentControllerSwagger{
     ) {
         commentService.deleteComment(commentId, principalHandler.getUserIdFromPrincipal());
         return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.of(SuccessMessage.COMMENT_DELETE_SUCCESS));
+    }
+
+    @PostMapping("/{commentId}")
+    public ResponseEntity<SuccessResponse> createCommentReply(
+            @CommentIdPathVariable final Long commentId,
+            @RequestBody final ReplyCreateRequest createRequest,
+            @PathVariable("commentId") final String commentUrl
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).header("Location",
+                commentService.createCommentReply(
+                        principalHandler.getUserIdFromPrincipal(),
+                        commentId, createRequest
+                )).body(SuccessResponse.of(SuccessMessage.REPLY_CREATE_SUCCESS));
+    }
+
+    @DeleteMapping("/reply/{replyId}")
+    public ResponseEntity<SuccessResponse> deleteCommentReply(
+            @ReplyIdPathVariable final Long replyId,
+            @PathVariable("replyId") final String replyUrl
+    ) {
+        commentService.deleteReply(principalHandler.getUserIdFromPrincipal(), replyId);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.REPLY_DELETE_SUCCESS));
     }
 }

--- a/module-api/src/main/java/com/mile/controller/comment/CommentControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/comment/CommentControllerSwagger.java
@@ -1,5 +1,6 @@
 package com.mile.controller.comment;
 
+import com.mile.commentreply.service.dto.ReplyCreateRequest;
 import com.mile.dto.ErrorResponse;
 import com.mile.dto.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,9 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
-import java.security.Principal;
-
-@Tag(name = "Comment", description = "댓글 관련 API - 현재는 댓글 삭제만 API 해당")
+@Tag(name = "Comment", description = "댓글 관련 API")
 public interface CommentControllerSwagger {
 
     @Operation(description = "댓글 삭제 API")
@@ -33,5 +32,41 @@ public interface CommentControllerSwagger {
     ResponseEntity<SuccessResponse> deleteComment(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long commentId,
             @PathVariable("commentId") final String commentUrl
+    );
+
+
+    @Operation(description = "대댓글 등록 API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "댓글 등록이 완료되었습니다."),
+                    @ApiResponse(responseCode = "403", description = "해당 사용자는 댓글에 접근 권한이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 댓글이 존재하지 않습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse> createCommentReply(
+            @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long commentId,
+            final ReplyCreateRequest createRequest,
+            @PathVariable("commentId") final String commentUrl
+    );
+
+    @Operation(description = "대댓글 삭제 API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "대댓글 삭제가 완료되었습니다."),
+                    @ApiResponse(responseCode = "403", description = "해당 사용자는 댓글에 접근 권한이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 댓글이 존재하지 않습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse> deleteCommentReply(
+            @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long replyId,
+            @PathVariable("replyId") final String replyUrl
     );
 }

--- a/module-common/src/main/java/com/mile/config/web/WebConfig.java
+++ b/module-common/src/main/java/com/mile/config/web/WebConfig.java
@@ -3,6 +3,7 @@ package com.mile.config.web;
 import com.mile.resolver.comment.CommentVariableResolver;
 import com.mile.resolver.moim.MoimVariableResolver;
 import com.mile.resolver.post.PostVariableResolver;
+import com.mile.resolver.reply.ReplyVariableResolver;
 import com.mile.resolver.topic.TopicVariableResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,7 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
+
 @RequiredArgsConstructor
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -18,6 +20,8 @@ public class WebConfig implements WebMvcConfigurer {
     private final TopicVariableResolver topicVariableResolver;
     private final PostVariableResolver postVariableResolver;
     private final CommentVariableResolver commentVariableResolver;
+    private final ReplyVariableResolver replyVariableResolver;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -32,5 +36,6 @@ public class WebConfig implements WebMvcConfigurer {
         resolvers.add(topicVariableResolver);
         resolvers.add(commentVariableResolver);
         resolvers.add(postVariableResolver);
+        resolvers.add(replyVariableResolver);
     }
 }

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -29,6 +29,7 @@ public enum ErrorMessage {
     TOPIC_POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글감의 글이 존재하지 않습니다."),
     MOIM_POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 모임의 글이 존재하지 않습니다."),
     RANDOM_VALUE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "랜덤 글 이름을 생성하는데 실패했습니다."),
+    REPLY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Id에 해당하는 대댓글이 없습니다."),
     /*
     Bad Request
      */
@@ -62,6 +63,7 @@ public enum ErrorMessage {
     Forbidden
      */
     USER_AUTHENTICATE_ERROR(HttpStatus.FORBIDDEN.value(), "해당 사용자는 모임에 접근 권한이 없습니다."),
+    REPLY_USER_FORBIDDEN(HttpStatus.UNAUTHORIZED.value(), "사용자에게 해당 대댓글에 대한 권한이 없습니다."),
     WRITER_AUTHENTICATE_ERROR(HttpStatus.FORBIDDEN.value(), "해당 사용자는 글 생성/수정/삭제 권한이 없습니다."),
     MOIM_OWNER_AUTHENTICATION_ERROR(HttpStatus.FORBIDDEN.value(), "사용자는 해당 모임의 모임장이 아닙니다."),
     /*

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -47,9 +47,11 @@ public enum SuccessMessage {
     TOPIC_DELETE_SUCCESS(HttpStatus.OK.value(), "글감 삭제가 완료되었습니다."),
     MOIM_WRITERNAME_LIST_GET_SUCCESS(HttpStatus.OK.value(), "멤버 리스트 조회가 완료되었습니다."),
     TEMPORARY_POST_DELETE_SUCCESS(HttpStatus.OK.value(), "임시 저장 글 삭제가 완료되었습니다."),
+    REPLY_DELETE_SUCCESS(HttpStatus.OK.value(), "대댓글 삭제가 완료되었습니다."),
     /*
     201 CREATED
      */
+    REPLY_CREATE_SUCCESS(HttpStatus.CREATED.value(), "대댓글 등록이 완료되었습니다."),
     WRITER_JOIN_SUCCESS(HttpStatus.CREATED.value(), "모임 가입에 완료되었습니다"),
     COMMENT_CREATE_SUCCESS(HttpStatus.CREATED.value(), "댓글 등록이 완료되었습니다."),
     CURIOUS_CREATE_SUCCESS(HttpStatus.CREATED.value(), "궁금해요 생성이 완료되었습니다."),

--- a/module-common/src/main/java/com/mile/resolver/reply/ReplyIdPathVariable.java
+++ b/module-common/src/main/java/com/mile/resolver/reply/ReplyIdPathVariable.java
@@ -1,0 +1,11 @@
+package com.mile.resolver.reply;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ReplyIdPathVariable {
+}

--- a/module-common/src/main/java/com/mile/resolver/reply/ReplyVariableResolver.java
+++ b/module-common/src/main/java/com/mile/resolver/reply/ReplyVariableResolver.java
@@ -1,0 +1,42 @@
+package com.mile.resolver.reply;
+
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.BadRequestException;
+import com.mile.utils.SecureUrlUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class ReplyVariableResolver implements HandlerMethodArgumentResolver {
+    private static final String REPLY_PATH_VARIABLE = "replyId";
+    private final SecureUrlUtil secureUrlUtil;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(ReplyIdPathVariable.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        final Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+
+        final String replyId = pathVariables.get(REPLY_PATH_VARIABLE);
+        System.out.println(replyId);
+        try {
+            return secureUrlUtil.decodeUrl(replyId);
+        } catch (NumberFormatException e) {
+            throw new BadRequestException(ErrorMessage.INVALID_URL_EXCEPTION);
+        }
+    }
+}

--- a/module-domain/src/main/java/com/mile/comment/service/CommentService.java
+++ b/module-domain/src/main/java/com/mile/comment/service/CommentService.java
@@ -3,6 +3,8 @@ package com.mile.comment.service;
 import com.mile.comment.domain.Comment;
 import com.mile.comment.repository.CommentRepository;
 import com.mile.comment.service.dto.CommentResponse;
+import com.mile.commentreply.service.CommentReplyService;
+import com.mile.commentreply.service.dto.ReplyCreateRequest;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.ForbiddenException;
 import com.mile.exception.model.NotFoundException;
@@ -29,6 +31,7 @@ public class CommentService {
     private final PostGetService postGetService;
     private final SecureUrlUtil secureUrlUtil;
     private final WriterNameService writerNameService;
+    private final CommentReplyService commentReplyService;
 
     @Transactional
     public void deleteComment(
@@ -37,6 +40,7 @@ public class CommentService {
     ) {
         Comment comment = findById(commentId);
         authenticateUser(comment, userId);
+        commentReplyService.deleteRepliesByComment(comment);
         delete(comment);
     }
 
@@ -74,6 +78,14 @@ public class CommentService {
         comment.setIdUrl(secureUrlUtil.encodeUrl(comment.getId()));
     }
 
+
+    public void deleteReply(
+            final Long userId,
+            final Long replyId
+    ) {
+        commentReplyService.deleteCommentReply(userId, replyId);
+    }
+
     private Comment create(
             final Post post,
             final WriterName writerName,
@@ -90,8 +102,30 @@ public class CommentService {
     ) {
         postAuthenticateService.authenticateUserWithPostId(postId, userId);
         List<Comment> commentList = findByPostId(postId);
+        Long writerNameId = writerNameService.getWriterNameIdByMoimIdAndUserId(moimId, userId);
         return commentList.stream()
-                .map(comment -> CommentResponse.of(comment, writerNameService.getWriterNameIdByMoimIdAndUserId(moimId, userId), isCommentWriterEqualWriterOfPost(comment, postId))).collect(Collectors.toList());
+                .map(comment -> CommentResponse.of(
+                        comment,
+                        writerNameId,
+                        isCommentWriterEqualWriterOfPost(comment, postId),
+                        commentReplyService.findRepliesByComment(comment, writerNameId))).collect(Collectors.toList());
+    }
+
+
+    public String createCommentReply(
+            final Long userId,
+            final Long commentId,
+            final ReplyCreateRequest replyCreateRequest
+    ) {
+        Comment comment = findById(commentId);
+        return commentReplyService.createCommentReply(
+                writerNameService.findWriterNameByMoimIdAndUserId(getMoimIdFromComment(comment), userId),
+                comment,
+                replyCreateRequest);
+    }
+
+    private Long getMoimIdFromComment(final Comment comment) {
+        return comment.getPost().getTopic().getMoim().getId();
     }
 
     private boolean isCommentWriterEqualWriterOfPost(
@@ -114,12 +148,6 @@ public class CommentService {
         return findByPostId(post.getId()).size();
     }
 
-
-    private boolean isCommentListNull(
-            final List<Comment> commentList
-    ) {
-        return commentList.isEmpty();
-    }
 
     public void deleteAllByPost(
             final Post post

--- a/module-domain/src/main/java/com/mile/comment/service/CommentService.java
+++ b/module-domain/src/main/java/com/mile/comment/service/CommentService.java
@@ -152,6 +152,7 @@ public class CommentService {
     public void deleteAllByPost(
             final Post post
     ) {
+        commentRepository.findByPostId(post.getId()).forEach(commentReplyService::deleteRepliesByComment);
         commentRepository.deleteAllByPost(post);
     }
 }

--- a/module-domain/src/main/java/com/mile/comment/service/dto/CommentResponse.java
+++ b/module-domain/src/main/java/com/mile/comment/service/dto/CommentResponse.java
@@ -1,14 +1,18 @@
 package com.mile.comment.service.dto;
 
 import com.mile.comment.domain.Comment;
+import com.mile.commentreply.service.dto.ReplyResponse;
 import com.mile.writername.domain.WriterName;
+
+import java.util.List;
 
 public record CommentResponse(
         String commentId,
         String name,
         String moimName,
         String content,
-        boolean isMyComment
+        boolean isMyComment,
+        List<ReplyResponse> replies
 ) {
     private final static String ANONYMOUS = "작자미상";
     private final static String AUTHOR = "글쓴이";
@@ -16,15 +20,17 @@ public record CommentResponse(
     public static CommentResponse of(
             final Comment comment,
             final Long writerNameId,
-            final boolean isWriterOfPost
+            final boolean isWriterOfPost,
+            final List<ReplyResponse> replies
     ) {
         WriterName writerName = comment.getWriterName();
         return new CommentResponse(
                 comment.getIdUrl(),
-                getNameString(comment,writerName,isWriterOfPost),
+                getNameString(comment, writerName, isWriterOfPost),
                 writerName.getMoim().getName(),
                 comment.getContent(),
-                writerName.getId().equals(writerNameId)
+                writerName.getId().equals(writerNameId),
+                replies
         );
     }
 

--- a/module-domain/src/main/java/com/mile/commentreply/domain/CommentReply.java
+++ b/module-domain/src/main/java/com/mile/commentreply/domain/CommentReply.java
@@ -1,0 +1,54 @@
+package com.mile.commentreply.domain;
+
+import com.mile.comment.domain.Comment;
+import com.mile.writername.domain.WriterName;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class CommentReply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    private WriterName writerName;
+    @ManyToOne
+    private Comment comment;
+    @Setter
+    private String idUrl;
+    private boolean isAnonymous;
+    private String content;
+
+    @Builder
+    private CommentReply(final WriterName writerName,
+                         final Comment comment,
+                         final boolean isAnonymous,
+                         final String content) {
+        this.writerName = writerName;
+        this.comment = comment;
+        this.isAnonymous = isAnonymous;
+        this.content = content;
+    }
+
+    public static CommentReply create(final WriterName writerName,
+                                      final Comment comment,
+                                      final String content,
+                                      final boolean isAnonymous) {
+        return CommentReply.builder()
+                .writerName(writerName)
+                .comment(comment)
+                .isAnonymous(isAnonymous)
+                .content(content)
+                .build();
+    }
+}

--- a/module-domain/src/main/java/com/mile/commentreply/repository/CommentReplyRepository.java
+++ b/module-domain/src/main/java/com/mile/commentreply/repository/CommentReplyRepository.java
@@ -1,0 +1,12 @@
+package com.mile.commentreply.repository;
+
+import com.mile.comment.domain.Comment;
+import com.mile.commentreply.domain.CommentReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentReplyRepository extends JpaRepository<CommentReply, Long> {
+
+    List<CommentReply> findByComment(final Comment comment);
+}

--- a/module-domain/src/main/java/com/mile/commentreply/service/CommentReplyService.java
+++ b/module-domain/src/main/java/com/mile/commentreply/service/CommentReplyService.java
@@ -1,0 +1,79 @@
+package com.mile.commentreply.service;
+
+import com.mile.comment.domain.Comment;
+import com.mile.commentreply.domain.CommentReply;
+import com.mile.commentreply.repository.CommentReplyRepository;
+import com.mile.commentreply.service.dto.ReplyCreateRequest;
+import com.mile.commentreply.service.dto.ReplyResponse;
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.NotFoundException;
+import com.mile.exception.model.UnauthorizedException;
+import com.mile.utils.SecureUrlUtil;
+import com.mile.writername.domain.WriterName;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentReplyService {
+
+    private final CommentReplyRepository commentReplyRepository;
+    private final SecureUrlUtil secureUrlUtil;
+
+    @Transactional
+    public String createCommentReply(
+            final WriterName writerName,
+            final Comment comment,
+            final ReplyCreateRequest replyCreateRequest
+    ) {
+        CommentReply commentReply = commentReplyRepository.save(CommentReply.create(writerName, comment, replyCreateRequest.content(), replyCreateRequest.isAnonymous()));
+        commentReply.setIdUrl(secureUrlUtil.encodeUrl(commentReply.getId()));
+        return commentReply.getId().toString();
+    }
+
+    public void deleteCommentReply(
+            final Long userId,
+            final Long replyId
+    ) {
+        CommentReply commentReply = findById(replyId);
+        authenticateReplyWithUserId(userId, commentReply);
+        commentReplyRepository.delete(commentReply);
+    }
+
+    private void authenticateReplyWithUserId(
+            final Long userId,
+            final CommentReply commentReply
+    ) {
+        if(!commentReply.getWriterName().getWriter().getId().equals(userId)) {
+            throw new UnauthorizedException(ErrorMessage.REPLY_USER_FORBIDDEN);
+        }
+    }
+
+    public void deleteRepliesByComment(
+            final Comment comment
+    ) {
+        commentReplyRepository.deleteAll(commentReplyRepository.findByComment(comment));
+    }
+    public List<ReplyResponse> findRepliesByComment(
+            final Comment comment,
+            final Long writerNameId
+    ) {
+        return commentReplyRepository.findByComment(comment).stream().map(c -> ReplyResponse.of(c, writerNameId, isWriterOfPost(c))).collect(Collectors.toList());
+    }
+
+    private boolean isWriterOfPost(final CommentReply commentReply) {
+        return commentReply.getComment().getPost().getWriterName().getId().equals(commentReply.getWriterName().getId());
+    }
+
+    private CommentReply findById(
+            final Long replyId
+    ) {
+        return commentReplyRepository.findById(replyId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.REPLY_NOT_FOUND)
+        );
+    }
+}

--- a/module-domain/src/main/java/com/mile/commentreply/service/dto/ReplyCreateRequest.java
+++ b/module-domain/src/main/java/com/mile/commentreply/service/dto/ReplyCreateRequest.java
@@ -1,0 +1,7 @@
+package com.mile.commentreply.service.dto;
+
+public record ReplyCreateRequest(
+        String content,
+        boolean isAnonymous
+) {
+}

--- a/module-domain/src/main/java/com/mile/commentreply/service/dto/ReplyResponse.java
+++ b/module-domain/src/main/java/com/mile/commentreply/service/dto/ReplyResponse.java
@@ -1,0 +1,48 @@
+package com.mile.commentreply.service.dto;
+
+import com.mile.comment.domain.Comment;
+import com.mile.comment.service.dto.CommentResponse;
+import com.mile.commentreply.domain.CommentReply;
+import com.mile.writername.domain.WriterName;
+
+import java.util.List;
+
+public record ReplyResponse(
+        String replyId,
+        String name,
+        String moimName,
+        String content,
+        boolean isMyReply
+) {
+    private final static String ANONYMOUS = "작자미상";
+    private final static String AUTHOR = "글쓴이";
+
+    public static ReplyResponse of(
+            final CommentReply commentReply,
+            final Long writerNameId,
+            final boolean isWriterOfPost
+    ) {
+        WriterName writerName = commentReply.getWriterName();
+        return new ReplyResponse(
+                commentReply.getIdUrl(),
+                getNameString(commentReply, writerName, isWriterOfPost),
+                writerName.getMoim().getName(),
+                commentReply.getContent(),
+                writerName.getId().equals(writerNameId)
+        );
+    }
+
+    private static String getNameString(
+            final CommentReply commentReply,
+            final WriterName writerName,
+            final boolean isWriterOfPost
+    ) {
+        if (isWriterOfPost) {
+            return AUTHOR;
+        } else if (commentReply.isAnonymous()) {
+            return ANONYMOUS + writerName.getId().toString();
+        } else {
+            return writerName.getName();
+        }
+    }
+}

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -110,6 +110,13 @@ public class WriterNameService {
         writerName.increaseTotalCuriousCount();
     }
 
+
+    public WriterName findWriterNameByMoimIdAndUserId(
+            final Long moimId,
+            final Long userId
+    ) {
+        return getById(getWriterNameIdByMoimIdAndUserId(moimId, userId));
+    }
     public List<WriterName> findTop2ByCuriousCount(final Long moimid) {
         return writerNameRepository.findTop2ByMoimIdAndTotalCuriousCountGreaterThanOrderByTotalCuriousCountDesc(moimid, MIN_TOTAL_CURIOUS_COUNT);
     }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #296 

## Key Changes 🔑
1. PathVariableResolver 구현해서 WebConfig에 등록해줬습니다 : 이 부분 등록 안해줘서 30분 동안 헤매였네요..
2. CommentReply 엔티티를 따로 만들어 대댓글을 등록할 테이블을 구성했습니다.
3. 대댓글 삭제 및 대댓글 등록 구현했습니다.
4. 게시글이나 댓글 삭제 시 관련 데이터 삭제를 위해 모두 삭제되는 로직을 추가했습니다.

## To Reviewers 📢
- 대댓글 관련 API를 모두 구현해서 코드가 다소 많습니다 ㅠ.ㅠ 
