### PR TITLE
#322 [feat] 베스트 모임 반환 로직 구현

### DIFF
--- a/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
+++ b/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
@@ -2,6 +2,7 @@ package com.mile.moim.repository;
 
 import com.mile.moim.domain.Moim;
 import com.mile.post.domain.Post;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,6 +15,11 @@ public interface MoimRepository extends JpaRepository<Moim, Long>, MoimRepositor
     Boolean existsByName(final String name);
 
     @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true AND p.createdAt BETWEEN :startOfWeek AND :endOfWeek GROUP BY m ORDER BY COUNT(p) DESC")
-    List<Moim> findTop3PrivateMoimsWithMostPostsLastWeek(Pageable pageable, @Param("startOfWeek") LocalDateTime startOfWeek, @Param("endOfWeek") LocalDateTime endOfWeek);
+    List<Moim> findTop3PublicMoimsWithMostPostsLastWeek(Pageable pageable, @Param("startOfWeek") LocalDateTime startOfWeek, @Param("endOfWeek") LocalDateTime endOfWeek);
 
+    @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true AND m NOT IN :excludeMoims GROUP BY m ORDER BY MAX(p.createdAt) DESC")
+    List<Moim> findLatestMoimsWithExclusion(Pageable pageable, @Param("excludeMoims") List<Moim> excludeMoims);
+
+    @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true GROUP BY m ORDER BY MAX(p.createdAt) DESC")
+    List<Moim> findLatestMoimsWithoutExclusion(Pageable pageable);
 }

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -182,9 +182,24 @@ public class MoimService {
         LocalDateTime endOfWeek = LocalDateTime.now();
         LocalDateTime startOfWeek = endOfWeek.minusDays(7);
         PageRequest pageRequest = PageRequest.of(0, 2);
-        List<Moim> moims = moimRepository.findTop3PrivateMoimsWithMostPostsLastWeek(pageRequest, startOfWeek, endOfWeek);
-        System.out.println(moims);
+        List<Moim> moims = moimRepository.findTop3PublicMoimsWithMostPostsLastWeek(pageRequest, startOfWeek, endOfWeek);
+
+        if (moims.size() < 3) {
+            int remaining = 3 - moims.size();
+            List<Moim> latestMoims = getLatestMoims(remaining, moims);
+            moims.addAll(latestMoims);
+        }
+
         return moims;
+    }
+
+    private List<Moim> getLatestMoims(int count, List<Moim> excludeMoims) {
+        PageRequest pageRequest = PageRequest.of(0, count);
+        if (excludeMoims.isEmpty()) {
+            return moimRepository.findLatestMoimsWithoutExclusion(pageRequest);
+        } else {
+            return moimRepository.findLatestMoimsWithExclusion(pageRequest, excludeMoims);
+        }
     }
 
     public BestMoimListResponse getBestMoimAndPostList() {

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -68,6 +68,7 @@ public class MoimService {
     private final SecureUrlUtil secureUrlUtil;
     private static final int WRITER_NAME_MAX_VALUE = 8;
     private static final int MOIM_NAME_MAX_VALUE = 10;
+    private static final int BEST_MOIM_DEFAULT_NUMBER = 3;
 
     public ContentListResponse getContentsFromMoim(
             final Long moimId,
@@ -179,18 +180,23 @@ public class MoimService {
     }
 
     public List<Moim> getBestMoimByPostNumber() {
-        LocalDateTime endOfWeek = LocalDateTime.now();
-        LocalDateTime startOfWeek = endOfWeek.minusDays(7);
-        PageRequest pageRequest = PageRequest.of(0, 2);
-        List<Moim> moims = moimRepository.findTop3PublicMoimsWithMostPostsLastWeek(pageRequest, startOfWeek, endOfWeek);
 
-        if (moims.size() < 3) {
-            int remaining = 3 - moims.size();
+        List<Moim> moims = findBestMoims();
+
+        if (moims.size() < BEST_MOIM_DEFAULT_NUMBER) {
+            int remaining = BEST_MOIM_DEFAULT_NUMBER - moims.size();
             List<Moim> latestMoims = getLatestMoims(remaining, moims);
             moims.addAll(latestMoims);
         }
 
         return moims;
+    }
+
+    private List<Moim> findBestMoims() {
+        LocalDateTime endOfWeek = LocalDateTime.now();
+        LocalDateTime startOfWeek = endOfWeek.minusDays(7);
+        PageRequest pageRequest = PageRequest.of(0, 2);
+        return moimRepository.findTop3PublicMoimsWithMostPostsLastWeek(pageRequest, startOfWeek, endOfWeek);
     }
 
     private List<Moim> getLatestMoims(int count, List<Moim> excludeMoims) {


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #322

## Key Changes 🔑
1. 로직 변경
  
기존 베스트 모임 반환 로직은
최근 1주일 간 가장 많은 글을 올린 top 3의 public 모임과 해당 모임의 글을 반환하는 것이었습니다.

이 경우, 최근 1주일간 글이 올라오지 않았을 때에는 모임이 아예 반환되지 않은 경우도 있었고, 3개 미달인 (1-2개) 경우도 있었습니다.

그래서 기획 요구사항에 따라,
최근 1주일 간 가장 많은 글을 올린 top 3의 public 모임과 해당 모임의 글을 반환하되, 
3개가 미달인 경우, 해당 부족분만큼 "최신 글이 올라온 모임을 반환"하도록 했습니다.


## To Reviewers 📢 
 1. Trouble Shooting

 최신 글이 올라온 모임을 반환할 때, top 3에 해당하는 모임과 겹치면 안되기 때문에 exlcudeMoims를 전달하여 해당 모임을 제외한 모임을 반환하도록
moimRepository.findLatestMoimsWithExclusion(pageRequest, excludeMoims); 을 하였습니다.
이 때 쿼리는 아래와 같이 작성했는데요
```java
    @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true AND m NOT IN :excludeMoims GROUP BY m ORDER BY MAX(p.createdAt) DESC")

```

그러나, 의도한 바와 다르게 쿼리 로그에 and 1=0 조건이 나타나서 빈 배열이 반환됐습니다. 알고 보니 이 문제는 findLatestMoimsWithExclusion 메소드에서 excludeMoims가 빈 리스트인 경우, JPA가 빈 컬렉션을 참조할 때 SQL에 1=0을 추가하여 쿼리가 아무것도 반환하지 않도록 처리하기 때문이었습니다.

즉, 만약 IN 절에 사용할 값 목록이 비어 있다면, 이 조건은 어떠한 값도 만족시키지 못합니다. 예를 들어 id IN ()와 같은 조건은 항상 거짓이 되어야 합니다. JPA는 이를 처리하기 위해, 자동으로 SQL에 1=0이라는 항상 거짓인 조건을 추가하게 됩니다.

이 쿼리에서 excludeMoims가 빈 리스트일 경우, m NOT IN () 조건이 추가되어야 하지만, 빈 리스트로는 SQL에서 의미있는 IN 절을 형성할 수 없기 때문에 결과적으로 JPA는 이를 1=0으로 변환하여 쿼리가 항상 거짓이 되도록 하고, 결국 빈 결과 집합을 반환했던 것이었습니다.

따라서 저는 이 문제를 해결하기 위해, 쿼리 호출 전 exlcudeMoims가 빈 리스트인지를 확인하고, 그에 따라 다른 쿼리를 실행하도록 (IN 절 없이) 변경하여 해결했습니다! 