### PR TITLE
#326 [feat] 동시성 이슈 관련 해결

### DIFF
--- a/module-domain/src/main/java/com/mile/curious/service/CuriousService.java
+++ b/module-domain/src/main/java/com/mile/curious/service/CuriousService.java
@@ -10,6 +10,7 @@ import com.mile.post.domain.Post;
 import com.mile.writername.domain.WriterName;
 import com.mile.writername.service.WriterNameService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -36,7 +37,11 @@ public class CuriousService {
 
     public void createCurious(final Post post, final WriterName writerName) {
         checkCuriousExists(post, writerName);
-        curiousRepository.save(Curious.create(post, writerName));
+        try {
+            curiousRepository.save(Curious.create(post, writerName));
+        } catch (DataIntegrityViolationException e) {
+            throw new ConflictException(ErrorMessage.CURIOUS_ALREADY_EXISTS_EXCEPTION);
+        }
         post.increaseCuriousCount();
         writerNameService.increaseTotalCuriousCountByWriterName(writerName);
     }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #326 

## Key Changes 🔑
1. 동시성 이슈 관련 해결했습니다 (아직 발생한 적은 있지만 충분히 발생할 수 있다고 생각해서! )
   - 현재는 post id 와 writer name id 가 각각 하나의 curious 테이블만 생성할 수 있다는 것을 보장해주는 데이터베이스 제약조건이 없었습니다. 이를 추가하고 만일 동시성(이중 체크임에도 불구하고 발생할 수 있는) 이슈가 발생했을 때, 해결하기 위한 코드를 구현했습니다.

## To Reviewers 📢
-
