### PR TITLE
#333 [feat] 글모임 뷰 - 필명 수정을 위한 플로우 구현

### DIFF
--- a/module-api/src/main/java/com/mile/controller/moim/MoimController.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimController.java
@@ -15,7 +15,6 @@ import com.mile.moim.service.dto.MoimInfoModifyRequest;
 import com.mile.moim.service.dto.MoimInfoOwnerResponse;
 import com.mile.moim.service.dto.MoimInfoResponse;
 import com.mile.moim.service.dto.MoimInvitationInfoResponse;
-import com.mile.moim.service.dto.MoimListOfUserResponse;
 import com.mile.moim.service.dto.MoimNameConflictCheckResponse;
 import com.mile.moim.service.dto.MoimTopicInfoListResponse;
 import com.mile.moim.service.dto.MoimTopicResponse;
@@ -27,6 +26,7 @@ import com.mile.moim.service.dto.TopicListResponse;
 import com.mile.moim.service.dto.WriterMemberJoinRequest;
 import com.mile.moim.service.dto.WriterNameConflictCheckResponse;
 import com.mile.resolver.moim.MoimIdPathVariable;
+import com.mile.writername.service.dto.WriterNameShortResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -245,6 +245,15 @@ public class MoimController implements MoimControllerSwagger {
             @PathVariable("moimId") final String moimUrl
     ) {
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_WRITERNAME_LIST_GET_SUCCESS, moimService.getWriterNameListOfMoim(moimId, principalHandler.getUserIdFromPrincipal(), page)));
+    }
+
+    @Override
+    @GetMapping("/{moimId}/writername")
+    public ResponseEntity<SuccessResponse<WriterNameShortResponse>> getWriterNameOfUser(
+            @MoimIdPathVariable final Long moimId,
+            @PathVariable("moimId") final String moimUrl
+    ) {
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.WRITER_NAME_GET_SUCCESS, moimService.getWriterNameOfUser(moimId, principalHandler.getUserIdFromPrincipal())));
     }
 
 }

--- a/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
@@ -12,7 +12,6 @@ import com.mile.moim.service.dto.MoimInfoModifyRequest;
 import com.mile.moim.service.dto.MoimInfoOwnerResponse;
 import com.mile.moim.service.dto.MoimInfoResponse;
 import com.mile.moim.service.dto.MoimInvitationInfoResponse;
-import com.mile.moim.service.dto.MoimListOfUserResponse;
 import com.mile.moim.service.dto.MoimNameConflictCheckResponse;
 import com.mile.moim.service.dto.MoimTopicInfoListResponse;
 import com.mile.moim.service.dto.MoimTopicResponse;
@@ -24,6 +23,7 @@ import com.mile.moim.service.dto.TopicListResponse;
 import com.mile.moim.service.dto.WriterMemberJoinRequest;
 import com.mile.moim.service.dto.WriterNameConflictCheckResponse;
 import com.mile.resolver.moim.MoimIdPathVariable;
+import com.mile.writername.service.dto.WriterNameShortResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -370,4 +370,19 @@ public interface MoimControllerSwagger {
             @PathVariable("moimId") final String moimUrl
     );
 
+    @Operation(summary = "글모임 뷰 - 내 필명 GET")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "필명 조회가 완료되었습니다."),
+                    @ApiResponse(responseCode = "404", description = "해당 모임은 존재하지 않습니다."),
+                    @ApiResponse(responseCode = "403", description = "해당 사용자는 모임에 접근 권한이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse<WriterNameShortResponse>> getWriterNameOfUser(
+            @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long moimId,
+            @PathVariable("moimId") final String moimUrl
+    );
 }

--- a/module-api/src/main/java/com/mile/controller/writername/WriterNameController.java
+++ b/module-api/src/main/java/com/mile/controller/writername/WriterNameController.java
@@ -4,19 +4,26 @@ import com.mile.authentication.PrincipalHandler;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
 import com.mile.writername.service.WriterNameDeleteService;
+import com.mile.writername.service.WriterNameService;
+import com.mile.writername.service.dto.WriterNameDescriptionResponse;
+import com.mile.writername.service.dto.WriterNameDescriptionUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/writerName")
-public class WriterNameController implements WriterNameControllerSwagger{
+public class WriterNameController implements WriterNameControllerSwagger {
 
     private final WriterNameDeleteService writerNameDeleteService;
+    private final WriterNameService writerNameService;
     private final PrincipalHandler principalHandler;
 
     @Override
@@ -26,5 +33,24 @@ public class WriterNameController implements WriterNameControllerSwagger{
     ) {
         writerNameDeleteService.deleteWriterNameById(writerNameId, principalHandler.getUserIdFromPrincipal());
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_MEMBER_DELETE_SUCCESS));
+    }
+
+
+    @Override
+    @GetMapping("/{writerNameId}/profile")
+    public ResponseEntity<SuccessResponse<WriterNameDescriptionResponse>> getWriterNameDescription(
+            @PathVariable("writerNameId") final Long writerNameId
+    ) {
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.WRITER_NAME_GET_SUCCESS, writerNameService.findWriterNameDescription(principalHandler.getUserIdFromPrincipal(), writerNameId)));
+    }
+
+    @Override
+    @PatchMapping("/{writerNameId}/description")
+    public ResponseEntity<SuccessResponse> updateWriterNameDescription(
+            @PathVariable("writerNameId") final Long writerNameId,
+            @RequestBody final WriterNameDescriptionUpdateRequest request
+    ) {
+        writerNameService.updateWriterNameDescription(principalHandler.getUserIdFromPrincipal(), writerNameId, request);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.WRITER_NAME_DESCRIPTION_UPDATE_SUCCESS));
     }
 }

--- a/module-api/src/main/java/com/mile/controller/writername/WriterNameControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/writername/WriterNameControllerSwagger.java
@@ -2,6 +2,8 @@ package com.mile.controller.writername;
 
 import com.mile.dto.ErrorResponse;
 import com.mile.dto.SuccessResponse;
+import com.mile.writername.service.dto.WriterNameDescriptionResponse;
+import com.mile.writername.service.dto.WriterNameDescriptionUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,6 +27,38 @@ public interface WriterNameControllerSwagger {
     )
     ResponseEntity<SuccessResponse> deleteMember(
             @PathVariable("writerNameId") final Long writerNameId
+    );
+
+    @Operation(summary = "필명, 소개글 조회")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "필명 소개글 조회가 완료되었습니다."),
+                    @ApiResponse(responseCode = "404", description = "해당 필명이 존재하지 않습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "해당 사용자는 필명에 접근 권한이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse<WriterNameDescriptionResponse>> getWriterNameDescription(
+            final Long writerNameId
+    );
+
+    @Operation(summary = "소개글 수정")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "소개글 수정이 완료 되었습니다."),
+                    @ApiResponse(responseCode = "400", description = "1. 소개 글이 입력되지 않았습니다.\n" +
+                            "2. 소개 글은 최대 110자 이내로 작성해주세요.\n",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 필명이 존재하지 않습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "해당 사용자는 필명에 접근 권한이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse> updateWriterNameDescription(
+            final Long writerNameId,
+            final WriterNameDescriptionUpdateRequest request
     );
 }
 

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -70,11 +70,8 @@ public enum ErrorMessage {
     REPLY_USER_FORBIDDEN(HttpStatus.UNAUTHORIZED.value(), "사용자에게 해당 대댓글에 대한 권한이 없습니다."),
     WRITER_AUTHENTICATE_ERROR(HttpStatus.FORBIDDEN.value(), "해당 사용자는 글 생성/수정/삭제 권한이 없습니다."),
     MOIM_OWNER_AUTHENTICATION_ERROR(HttpStatus.FORBIDDEN.value(), "사용자는 해당 모임의 모임장이 아닙니다."),
-    /*
-    Forbidden
-     */
+    WRITER_NAME_INFO_FORBIDDEN(HttpStatus.FORBIDDEN.value(), "해당 사용자는 필명에 접근 권한이 없습니다."),
     COMMENT_ACCESS_ERROR(HttpStatus.FORBIDDEN.value(), "해당 사용자는 댓글에 접근 권한이 없습니다."),
-    OWNER_AUTHENTICATE_ERROR(HttpStatus.FORBIDDEN.value(), "사용자는 해당 모임의 모임장이 아닙니다."),
     /*
     Method Not Supported
      */

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -50,6 +50,8 @@ public enum SuccessMessage {
     REPLY_DELETE_SUCCESS(HttpStatus.OK.value(), "대댓글 삭제가 완료되었습니다."),
     MOIM_LIST_OF_USER_GET_SUCCESS(HttpStatus.OK.value(), "모임 리스트 조회가 완료되었습니다."),
     WRITER_NAME_GET_SUCCESS(HttpStatus.OK.value(), "필명 조회가 완료되었습니다."),
+    WRITER_NAME_DESCRIPTION_GET_SUCCESS(HttpStatus.OK.value(), "필명 소개글 조회가 완료되었습니다."),
+    WRITER_NAME_DESCRIPTION_UPDATE_SUCCESS(HttpStatus.OK.value(), "소개글 수정이 완료 되었습니다."),
     /*
     201 CREATED
      */

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -49,6 +49,7 @@ public enum SuccessMessage {
     TEMPORARY_POST_DELETE_SUCCESS(HttpStatus.OK.value(), "임시 저장 글 삭제가 완료되었습니다."),
     REPLY_DELETE_SUCCESS(HttpStatus.OK.value(), "대댓글 삭제가 완료되었습니다."),
     MOIM_LIST_OF_USER_GET_SUCCESS(HttpStatus.OK.value(), "모임 리스트 조회가 완료되었습니다."),
+    WRITER_NAME_GET_SUCCESS(HttpStatus.OK.value(), "필명 조회가 완료되었습니다."),
     /*
     201 CREATED
      */

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -38,6 +38,7 @@ import com.mile.utils.DateUtil;
 import com.mile.utils.SecureUrlUtil;
 import com.mile.writername.domain.WriterName;
 import com.mile.writername.service.WriterNameService;
+import com.mile.writername.service.dto.WriterNameShortResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -72,6 +73,13 @@ public class MoimService {
     ) {
         postAuthenticateService.authenticateUserOfMoim(moimId, userId);
         return ContentListResponse.of(topicService.getContentsFromMoim(moimId));
+    }
+
+    public WriterNameShortResponse getWriterNameOfUser(
+            final Long moimId,
+            final Long userId
+    ) {
+        return writerNameService.findWriterNameInfo(moimId, userId);
     }
 
     public WriterNameConflictCheckResponse checkConflictOfWriterName(Long moimId, String writerName) {
@@ -241,7 +249,7 @@ public class MoimService {
         Long writerNameId = writerNameService.getWriterNameIdByMoimIdAndUserId(moimId, userId);
         Moim moim = findById(moimId);
         if (!moim.getOwner().getId().equals(writerNameId)) {
-            throw new ForbiddenException(ErrorMessage.OWNER_AUTHENTICATE_ERROR);
+            throw new ForbiddenException(ErrorMessage.MOIM_OWNER_AUTHENTICATION_ERROR);
         }
     }
 

--- a/module-domain/src/main/java/com/mile/writername/domain/WriterName.java
+++ b/module-domain/src/main/java/com/mile/writername/domain/WriterName.java
@@ -3,6 +3,7 @@ package com.mile.writername.domain;
 import com.mile.moim.domain.Moim;
 import com.mile.moim.service.dto.WriterMemberJoinRequest;
 import com.mile.user.domain.User;
+import com.mile.writername.service.dto.WriterNameDescriptionUpdateRequest;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -52,6 +53,9 @@ public class WriterName {
         validateTotalCuriousCount();
     }
 
+    public void updateInformation(WriterNameDescriptionUpdateRequest request) {
+        this.information = request.description();
+    }
     @Builder
     private WriterName(
             final Moim moim,

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -69,7 +69,7 @@ public class WriterNameService {
     }
 
     private void checkWriterNameUserId(final Long userId, final WriterName writerName) {
-        if (!writerName.getId().equals(userId)) {
+        if (!writerName.getWriter().getId().equals(userId)) {
             throw new ForbiddenException(ErrorMessage.WRITER_NAME_INFO_FORBIDDEN);
         }
     }

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -1,10 +1,10 @@
 package com.mile.writername.service;
 
 import com.mile.comment.service.CommentGetService;
-import com.mile.comment.service.CommentService;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.BadRequestException;
 import com.mile.exception.model.ConflictException;
+import com.mile.exception.model.ForbiddenException;
 import com.mile.exception.model.NotFoundException;
 import com.mile.moim.domain.Moim;
 import com.mile.moim.service.dto.MoimWriterNameListGetResponse;
@@ -14,7 +14,10 @@ import com.mile.post.service.PostGetService;
 import com.mile.user.domain.User;
 import com.mile.writername.domain.WriterName;
 import com.mile.writername.repository.WriterNameRepository;
+import com.mile.writername.service.dto.WriterNameDescriptionResponse;
+import com.mile.writername.service.dto.WriterNameDescriptionUpdateRequest;
 import com.mile.writername.service.dto.WriterNameInfoResponse;
+import com.mile.writername.service.dto.WriterNameShortResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -48,17 +51,45 @@ public class WriterNameService {
                         () -> new NotFoundException(ErrorMessage.WRITER_NOT_FOUND)
                 );
     }
+
     public boolean isUserInMoim(
             final Long moimId,
             final Long writerId
     ) {
         return writerNameRepository.existsWriterNameByMoimIdAndWriterId(moimId, writerId);
     }
+
+    public WriterNameDescriptionResponse findWriterNameDescription(
+            final Long userId,
+            final Long writerNameId
+    ) {
+        WriterName writerName = findById(writerNameId);
+        checkWriterNameUserId(userId, writerName);
+        return WriterNameDescriptionResponse.of(writerName);
+    }
+
+    private void checkWriterNameUserId(final Long userId, final WriterName writerName) {
+        if (!writerName.getId().equals(userId)) {
+            throw new ForbiddenException(ErrorMessage.WRITER_NAME_INFO_FORBIDDEN);
+        }
+    }
+
     public WriterNameShortResponse findWriterNameInfo(
             final Long moimId,
             final Long userId
     ) {
         return WriterNameShortResponse.of(findByMoimAndUser(moimId, userId));
+    }
+
+    @Transactional
+    public void updateWriterNameDescription(
+            final Long userId,
+            final Long writerNameId,
+            final WriterNameDescriptionUpdateRequest request
+    ) {
+        WriterName writerName = findById(writerNameId);
+        checkWriterNameUserId(userId, writerName);
+        writerName.updateInformation(request);
     }
 
     private void checkWriterNameOverFive(

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -54,6 +54,12 @@ public class WriterNameService {
     ) {
         return writerNameRepository.existsWriterNameByMoimIdAndWriterId(moimId, writerId);
     }
+    public WriterNameShortResponse findWriterNameInfo(
+            final Long moimId,
+            final Long userId
+    ) {
+        return WriterNameShortResponse.of(findByMoimAndUser(moimId, userId));
+    }
 
     private void checkWriterNameOverFive(
             final User user

--- a/module-domain/src/main/java/com/mile/writername/service/dto/WriterNameDescriptionResponse.java
+++ b/module-domain/src/main/java/com/mile/writername/service/dto/WriterNameDescriptionResponse.java
@@ -1,0 +1,16 @@
+package com.mile.writername.service.dto;
+
+import com.mile.writername.domain.WriterName;
+
+public record WriterNameDescriptionResponse(
+        String name,
+        String description
+
+) {
+
+    public static WriterNameDescriptionResponse of(
+            final WriterName writerName
+    ) {
+        return new WriterNameDescriptionResponse(writerName.getName(), writerName.getInformation());
+    }
+}

--- a/module-domain/src/main/java/com/mile/writername/service/dto/WriterNameDescriptionUpdateRequest.java
+++ b/module-domain/src/main/java/com/mile/writername/service/dto/WriterNameDescriptionUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.mile.writername.service.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+
+public record WriterNameDescriptionUpdateRequest(
+        @NotBlank(message = "소개 글이 입력되지 않았습니다.")
+        @Max(value = 110, message = "소개 글은 최대 110자 이내로 작성해주세요.")
+        String description
+) {
+}

--- a/module-domain/src/main/java/com/mile/writername/service/dto/WriterNameShortResponse.java
+++ b/module-domain/src/main/java/com/mile/writername/service/dto/WriterNameShortResponse.java
@@ -1,0 +1,12 @@
+package com.mile.writername.service.dto;
+
+import com.mile.writername.domain.WriterName;
+
+public record WriterNameShortResponse(
+        String writerName,
+        Long writerNameId
+) {
+    public static WriterNameShortResponse of(final WriterName writerName) {
+        return new WriterNameShortResponse(writerName.getName(), writerName.getId());
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #333 

## Key Changes 🔑
1. WriterName에서 짧은 내용만 Get 하는 Response -> module-domain/src/main/java/com/mile/writername/service/dto/WriterNameShortResponse.java

2. WriterName Description도 함께 Get하는 Response -> module-domain/src/main/java/com/mile/writername/service/dto/WriterNameDescriptionResponse.java

3. 소개글 수정을 위한 Patch API 구현

## To Reviewers 📢
- 놓친 부분을 뒤늦게 확인하고 빠르게 구현하느라 전달을 못했습니다!.. 그리고 3가지 API를 함께하느라 PR이 다소 큽니다..! 양해 부탁드려요!
저희가 이 플로우를 놓쳤더라구요!
![image](https://github.com/Mile-Writings/Mile-Server/assets/79795051/7d65c6a7-5d2e-47a9-91e0-3c35a4fbe89e)
이 세개의 API를 구현했습니다!
![image](https://github.com/Mile-Writings/Mile-Server/assets/79795051/8ead96dd-6432-4d3c-856a-05217bda6f6e)

