### PR TITLE
#340 [feat] 중복된 요청 에러 처리

### DIFF
--- a/module-api/src/main/java/com/mile/controller/comment/CommentController.java
+++ b/module-api/src/main/java/com/mile/controller/comment/CommentController.java
@@ -1,7 +1,7 @@
 package com.mile.controller.comment;
 
 
-import com.mile.authentication.PrincipalHandler;
+import com.mile.config.filter.PrincipalHandler;
 import com.mile.comment.service.CommentService;
 import com.mile.commentreply.service.dto.ReplyCreateRequest;
 import com.mile.dto.SuccessResponse;

--- a/module-api/src/main/java/com/mile/controller/moim/MoimController.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimController.java
@@ -1,6 +1,6 @@
 package com.mile.controller.moim;
 
-import com.mile.authentication.PrincipalHandler;
+import com.mile.config.filter.PrincipalHandler;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
 import com.mile.moim.service.MoimService;

--- a/module-api/src/main/java/com/mile/controller/post/PostController.java
+++ b/module-api/src/main/java/com/mile/controller/post/PostController.java
@@ -1,6 +1,6 @@
 package com.mile.controller.post;
 
-import com.mile.authentication.PrincipalHandler;
+import com.mile.config.filter.PrincipalHandler;
 import com.mile.curious.service.dto.CuriousInfoResponse;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;

--- a/module-api/src/main/java/com/mile/controller/topic/TopicController.java
+++ b/module-api/src/main/java/com/mile/controller/topic/TopicController.java
@@ -1,6 +1,6 @@
 package com.mile.controller.topic;
 
-import com.mile.authentication.PrincipalHandler;
+import com.mile.config.filter.PrincipalHandler;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
 import com.mile.resolver.topic.TopicIdPathVariable;

--- a/module-api/src/main/java/com/mile/controller/user/UserController.java
+++ b/module-api/src/main/java/com/mile/controller/user/UserController.java
@@ -1,6 +1,6 @@
 package com.mile.controller.user;
 
-import com.mile.authentication.PrincipalHandler;
+import com.mile.config.filter.PrincipalHandler;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
 import com.mile.external.client.dto.UserLoginRequest;

--- a/module-api/src/main/java/com/mile/controller/writername/WriterNameController.java
+++ b/module-api/src/main/java/com/mile/controller/writername/WriterNameController.java
@@ -1,6 +1,6 @@
 package com.mile.controller.writername;
 
-import com.mile.authentication.PrincipalHandler;
+import com.mile.config.filter.PrincipalHandler;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
 import com.mile.writername.service.WriterNameDeleteService;

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     //Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
+    //Redisson
+    implementation "org.redisson:redisson:3.29.0"
     //Aop
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 }

--- a/module-common/src/main/java/com/mile/config/filter/PrincipalHandler.java
+++ b/module-common/src/main/java/com/mile/config/filter/PrincipalHandler.java
@@ -1,4 +1,4 @@
-package com.mile.authentication;
+package com.mile.config.filter;
 
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.UnauthorizedException;

--- a/module-common/src/main/java/com/mile/config/redis/RedisConfig.java
+++ b/module-common/src/main/java/com/mile/config/redis/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.mile.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    RedissonClient getRedissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        return Redisson.create(config);
+    }
+}

--- a/module-common/src/main/java/com/mile/config/web/WebConfig.java
+++ b/module-common/src/main/java/com/mile/config/web/WebConfig.java
@@ -33,14 +33,6 @@ public class WebConfig implements WebMvcConfigurer {
                 .maxAge(3000);
     }
 
-    /*
-    - 글 임시저장 `{{base_url}}/api/post/temporary`
-- 글 작성 `{{base_url}}/api/post`
-- 댓글 작성 `{{base_url}}/api/post/:postId/comment`
-- 대댓글 작성 `{{base_url}}/api/comment/:commentId`
-- 글감 생성 `{{base_url}}/api/moim/:moimId/topic`
-     */
-
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(duplicatedInterceptor)

--- a/module-common/src/main/java/com/mile/config/web/WebConfig.java
+++ b/module-common/src/main/java/com/mile/config/web/WebConfig.java
@@ -1,5 +1,6 @@
 package com.mile.config.web;
 
+import com.mile.interceptor.DuplicatedInterceptor;
 import com.mile.resolver.comment.CommentVariableResolver;
 import com.mile.resolver.moim.MoimVariableResolver;
 import com.mile.resolver.post.PostVariableResolver;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -21,6 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
     private final PostVariableResolver postVariableResolver;
     private final CommentVariableResolver commentVariableResolver;
     private final ReplyVariableResolver replyVariableResolver;
+    private final DuplicatedInterceptor duplicatedInterceptor;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -28,6 +31,20 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins("*")
                 .allowedMethods("GET", "POST", "DELETE", "PUT", "PATCH")
                 .maxAge(3000);
+    }
+
+    /*
+    - 글 임시저장 `{{base_url}}/api/post/temporary`
+- 글 작성 `{{base_url}}/api/post`
+- 댓글 작성 `{{base_url}}/api/post/:postId/comment`
+- 대댓글 작성 `{{base_url}}/api/comment/:commentId`
+- 글감 생성 `{{base_url}}/api/moim/:moimId/topic`
+     */
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(duplicatedInterceptor)
+                .addPathPatterns("/api/post/temporary", "/api/post", "/api/post/{postId}/comment","/api/comment/{commentId}", "/api/moim/{moimId}/topic");
     }
 
     @Override

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -77,6 +77,10 @@ public enum ErrorMessage {
      */
     METHOD_NOT_SUPPORTED(HttpStatus.METHOD_NOT_ALLOWED.value(), "요청을 다시 확인해주세요."),
     /*
+    Too Many Requests
+     */
+    TOO_MANY_REQUESTS_EXCEPTION(HttpStatus.TOO_MANY_REQUESTS.value(),"요청이 중복되었습니다."),
+    /*
     Internal Server Error
      */
     IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "S3 버킷에 이미지를 업로드에 실패했습니다."),

--- a/module-common/src/main/java/com/mile/exception/model/TooManyRequestException.java
+++ b/module-common/src/main/java/com/mile/exception/model/TooManyRequestException.java
@@ -1,0 +1,9 @@
+package com.mile.exception.model;
+
+import com.mile.exception.message.ErrorMessage;
+
+public class TooManyRequestException extends MileException{
+    public TooManyRequestException(final ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/module-common/src/main/java/com/mile/handler/GlobalExceptionHandler.java
+++ b/module-common/src/main/java/com/mile/handler/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.mile.exception.model.ConflictException;
 import com.mile.exception.model.ForbiddenException;
 import com.mile.exception.model.JwtValidationException;
 import com.mile.exception.model.NotFoundException;
+import com.mile.exception.model.TooManyRequestException;
 import com.mile.exception.model.UnauthorizedException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -87,6 +88,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ConflictException.class)
     public ResponseEntity<ErrorResponse> handleConflictException(final ConflictException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponse.of(e.getErrorMessage()));
+    }
+
+    @ExceptionHandler(TooManyRequestException.class)
+    public ResponseEntity<ErrorResponse> handleTooManyRequestException(final TooManyRequestException e) {
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(ErrorResponse.of(e.getErrorMessage()));
     }
 
     @ExceptionHandler({NoHandlerFoundException.class})

--- a/module-common/src/main/java/com/mile/interceptor/DuplicatedInterceptor.java
+++ b/module-common/src/main/java/com/mile/interceptor/DuplicatedInterceptor.java
@@ -1,0 +1,9 @@
+package com.mile.interceptor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class DuplicatedInterceptor implements HandlerInterceptor {
+
+}

--- a/module-common/src/main/java/com/mile/interceptor/DuplicatedInterceptor.java
+++ b/module-common/src/main/java/com/mile/interceptor/DuplicatedInterceptor.java
@@ -1,9 +1,34 @@
 package com.mile.interceptor;
 
+import com.mile.config.filter.PrincipalHandler;
+import com.mile.filter.wrapper.CachedBodyRequestWrapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
+@RequiredArgsConstructor
 public class DuplicatedInterceptor implements HandlerInterceptor {
 
+    private static final String REDIS_KEY = "MILE_REDIS";
+    private static final String RMAP_VALUE = "MILE";
+    private final RedissonClient redissonClient;
+    private final PrincipalHandler principalHandler;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+
+    }
+
+    private String getRmapKey() {
+        return principalHandler.getUserIdFromPrincipal().toString();
+    }
+
+    private boolean lock(HttpSerletRequest request) {
+        final String rmapKey = getRmapKey()
+    }
 }
+


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #340

## Key Changes 🔑

글 생성에 대한 동시성 이슈를 발견하고, 해결하기 위해 중복된 요청에 대한 에러 처리를 하였습니다.
DuplicatedInterceptor에서 UserId 기반으로 키를 생성합니다.
요청이 들어오면 이 키가 이미 존재하는지 확인하고,
없으면 저장하여 요청을 처리합니다.
만약 이미 존재하면, TooManyRequestException 예외를 발생합니다.

요청 완료 후 Redis에서 해당 키를 삭제하는 로직입니다!


