### PR TITLE
#341 [feat] 글감별 글 조회 무한 스크롤(페이지네이션) 구현

### DIFF
--- a/module-api/src/main/java/com/mile/controller/topic/TopicController.java
+++ b/module-api/src/main/java/com/mile/controller/topic/TopicController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -30,9 +31,10 @@ public class TopicController implements TopicControllerSwagger {
     @GetMapping("/{topicId}")
     public SuccessResponse<PostListInTopicResponse> getPostListByTopic(
             @TopicIdPathVariable Long topicId,
-            @PathVariable("topicId") final String topicUrl
+            @PathVariable("topicId") final String topicUrl,
+            @RequestParam(required = false) final String lastPostId
     ) {
-        return SuccessResponse.of(SuccessMessage.MOIM_POST_GET_SUCCESS, topicService.getPostListByTopic(topicId));
+        return SuccessResponse.of(SuccessMessage.MOIM_POST_GET_SUCCESS, topicService.getPostListByTopic(topicId, lastPostId));
     }
 
     @Override

--- a/module-api/src/main/java/com/mile/controller/topic/TopicControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/topic/TopicControllerSwagger.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Topic")
 public interface TopicControllerSwagger {
@@ -34,7 +35,8 @@ public interface TopicControllerSwagger {
     )
     SuccessResponse<PostListInTopicResponse> getPostListByTopic(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long topicId,
-            @PathVariable("topicId") final String topicUrl
+            @PathVariable("topicId") final String topicUrl,
+            @RequestParam(required = false) final String lastPostId
     );
 
     @Operation(summary = "관리자 페이지 - 글감 상세 정보")

--- a/module-common/src/main/java/com/mile/utils/SecureUrlUtil.java
+++ b/module-common/src/main/java/com/mile/utils/SecureUrlUtil.java
@@ -10,7 +10,7 @@ import java.util.Base64;
 public class SecureUrlUtil {
 
     public String encodeUrl(final Long id) {
-        return  Base64.getUrlEncoder().encodeToString(id.toString().getBytes());
+        return Base64.getUrlEncoder().encodeToString(id.toString().getBytes());
     }
 
     public Long decodeUrl(final String url) {
@@ -19,6 +19,10 @@ public class SecureUrlUtil {
         } catch (IllegalArgumentException e) {
             throw new BadRequestException(ErrorMessage.PATH_PARAMETER_INVALID_ERROR);
         }
+    }
+
+    public Long decodeIfNotNull(final String url) {
+        return url == null ? null : decodeUrl(url);
     }
 
 }

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepositoryCustom.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepositoryCustom.java
@@ -2,7 +2,10 @@ package com.mile.post.repository;
 
 import com.mile.moim.domain.Moim;
 import com.mile.post.domain.Post;
+import com.mile.topic.domain.Topic;
 import com.mile.writername.domain.WriterName;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,5 +16,6 @@ public interface PostRepositoryCustom {
     List<Post> findLatest4NonTemporaryPostsByMoim(Moim moim);
 
     Optional<Post> findByMoimAndWriterNameWhereIsTemporary(final Moim moim, final WriterName writerName);
-}
 
+    Slice<Post> findByTopicAndLastPostId(final Topic topic, final Pageable pageable, final Long lastPostId);
+}

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepositoryCustomImpl.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepositoryCustomImpl.java
@@ -2,9 +2,15 @@ package com.mile.post.repository;
 
 import com.mile.moim.domain.Moim;
 import com.mile.post.domain.Post;
+import com.mile.topic.domain.Topic;
 import com.mile.writername.domain.WriterName;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
 import java.util.Optional;
@@ -52,4 +58,29 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                 .on(post.writerName.eq(requestWriterName))
                 .where(post.isTemporary.eq(true)).fetchOne());
     }
+
+    public Slice<Post> findByTopicAndLastPostId(final Topic topic, final Pageable pageable, final Long lastPostId) {
+        List<Post> result = jpaQueryFactory.selectFrom(post)
+                .where(post.topic.eq(topic))
+                .where(greaterThanLastPostId(lastPostId))
+                .where(post.isTemporary.eq(false))
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        return checkLastPage(pageable, result);
+    }
+
+    private BooleanExpression greaterThanLastPostId(final Long lastPostId) {
+        return lastPostId != null ? post.id.gt(lastPostId) : null;
+    }
+
+    private Slice<Post> checkLastPage(final Pageable pageable, final List<Post> posts) {
+        boolean hasNext = false;
+        if (posts.size() > pageable.getPageSize()) {
+            posts.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+        return new SliceImpl<>(posts, pageable, hasNext);
+    }
+
 }

--- a/module-domain/src/main/java/com/mile/topic/service/dto/PostListInTopicResponse.java
+++ b/module-domain/src/main/java/com/mile/topic/service/dto/PostListInTopicResponse.java
@@ -6,12 +6,14 @@ import java.util.List;
 
 public record PostListInTopicResponse(
         TopicOfMoimResponse topicInfo,
-        List<PostListResponse> postList
+        List<PostListResponse> postList,
+        boolean hasNext
 ) {
     public static PostListInTopicResponse of(
             final TopicOfMoimResponse topicInfo,
-            final List<PostListResponse> postList
+            final List<PostListResponse> postList,
+            final boolean hasNext
     ) {
-        return new PostListInTopicResponse(topicInfo, postList);
+        return new PostListInTopicResponse(topicInfo, postList, hasNext);
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #341 

## Key Changes 🔑
1. 무한 스크롤의 경우, 커서 기반 페이지네이션을 진행합니다.

기존 페이지네이션의 경우 offset 기반으로 지금 있는 페이지에 해당하는 값들을 보여줍니다. 무한 스크롤의 경우 받아온 데이터 이후의 값만 보내줘야하기 때문에 현재 커서가 어디있는지를 뜻하여 커서 기반 페이지네이션을 진행합니다.

2. 이를 위해서 받아와야 하는 값은 지금까지 받아온 값의 가장 최상의 ID입니다.
RequestParameter로 해당 값이 Null이 될 수 있도록 설정하였습니다.

3. 리턴값에 hasNext 필드를 추가하여 다음 페이지가 있는지 포함하여 만일 이 페이지가 마지막일 경우를 담았습니다.
-> 이는 우선 SQL문을 통해 7개를 뽑은 후, 7개가 된다면 PageSize보다 큰 것이기 때문에 다음 페이지가 있다는 것으로 판단하여 Boolean 값을 리턴했습니다.

## To Reviewers 📢
- 
