### PR TITLE
#385 [feat] 글모임 삭제 API 구현

### DIFF
--- a/module-api/src/main/java/com/mile/controller/moim/MoimController.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimController.java
@@ -3,6 +3,7 @@ package com.mile.controller.moim;
 import com.mile.config.filter.PrincipalHandler;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
+import com.mile.moim.service.MoimDeleteService;
 import com.mile.moim.service.MoimService;
 import com.mile.moim.service.dto.BestMoimListResponse;
 import com.mile.moim.service.dto.ContentListResponse;
@@ -57,6 +58,7 @@ import java.net.URI;
 public class MoimController implements MoimControllerSwagger {
 
     private final MoimService moimService;
+    private final MoimDeleteService moimDeleteService;
     private final PrincipalHandler principalHandler;
 
     @Override
@@ -283,9 +285,8 @@ public class MoimController implements MoimControllerSwagger {
             @MoimIdPathVariable final Long moimId,
             @PathVariable("moimId") final String moimUrl
     ) {
-        moimService.deleteMoim(moimId, principalHandler.getUserIdFromPrincipal());
+        moimDeleteService.deleteMoim(moimId, principalHandler.getUserIdFromPrincipal());
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_DELETE_SUCCESS));
-
     }
 
 }

--- a/module-api/src/main/java/com/mile/controller/moim/MoimController.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimController.java
@@ -39,6 +39,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -274,6 +275,17 @@ public class MoimController implements MoimControllerSwagger {
     ) {
         return SuccessResponse.of(SuccessMessage.MOIM_PUBLIC_STATUS_GET_SUCCESS,
                 moimService.getPublicStatusOfMoim(moimId));
+    }
+
+    @Override
+    @DeleteMapping("/{moimId}")
+    public ResponseEntity<SuccessResponse> deleteMoim(
+            @MoimIdPathVariable final Long moimId,
+            @PathVariable("moimId") final String moimUrl
+    ) {
+        moimService.deleteMoim(moimId, principalHandler.getUserIdFromPrincipal());
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_DELETE_SUCCESS));
+
     }
 
 }

--- a/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
@@ -399,4 +399,18 @@ public interface MoimControllerSwagger {
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long moimId,
             @PathVariable("moimId") final String moimUrl
     );
+
+    @Operation(summary = "글모임 삭제 API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "글모임 삭제가 완료되었습니다."),
+                    @ApiResponse(responseCode = "404", description = "해당 모임은 존재하지 않습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse> deleteMoim(
+            @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long moimId,
+            @PathVariable("moimId") final String moimUrl
+    );
 }

--- a/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
@@ -404,6 +404,8 @@ public interface MoimControllerSwagger {
     @ApiResponses(
             value = {
                     @ApiResponse(responseCode = "200", description = "글모임 삭제가 완료되었습니다."),
+                    @ApiResponse(responseCode = "403", description = "사용자는 해당 모임의 모임장이 아닙니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "404", description = "해당 모임은 존재하지 않습니다."),
                     @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))

--- a/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/SuccessMessage.java
@@ -53,6 +53,7 @@ public enum SuccessMessage {
     WRITER_NAME_DESCRIPTION_GET_SUCCESS(HttpStatus.OK.value(), "필명 소개글 조회가 완료되었습니다."),
     WRITER_NAME_DESCRIPTION_UPDATE_SUCCESS(HttpStatus.OK.value(), "소개글 수정이 완료 되었습니다."),
     MOIM_PUBLIC_STATUS_GET_SUCCESS(HttpStatus.OK.value(), "글모임 공개여부 조회가 완료되었습니다."),
+    MOIM_DELETE_SUCCESS(HttpStatus.OK.value(), "글모임 삭제가 완료되었습니다."),
     /*
     201 CREATED
      */

--- a/module-domain/src/main/java/com/mile/comment/service/CommentService.java
+++ b/module-domain/src/main/java/com/mile/comment/service/CommentService.java
@@ -137,7 +137,7 @@ public class CommentService {
         return post.getWriterName().equals(comment.getWriterName());
     }
 
-    private List<Comment> findByPostId(
+    public List<Comment> findByPostId(
             final Long postId
     ) {
         return commentRepository.findByPostId(postId);
@@ -172,5 +172,17 @@ public class CommentService {
             final Post post
     ) {
         return commentRepository.countByPost(post) + findCommentReplyByPost(post);
+    }
+
+    public List<Comment> findAllByPosts(
+            final List<Post> posts
+    ) {
+        return posts.stream()
+                .flatMap(post -> findByPostId(post.getId()).stream())
+                .collect(Collectors.toList());
+    }
+
+    public void deleteComments(final List<Comment> comments) {
+        comments.forEach(comment -> delete(comment));
     }
 }

--- a/module-domain/src/main/java/com/mile/commentreply/service/CommentReplyService.java
+++ b/module-domain/src/main/java/com/mile/commentreply/service/CommentReplyService.java
@@ -83,4 +83,8 @@ public class CommentReplyService {
                 () -> new NotFoundException(ErrorMessage.REPLY_NOT_FOUND)
         );
     }
+
+    public void deleteRepliesByComments(final List<Comment> comments) {
+        comments.forEach(comment -> deleteRepliesByComment(comment));
+    }
 }

--- a/module-domain/src/main/java/com/mile/curious/service/CuriousService.java
+++ b/module-domain/src/main/java/com/mile/curious/service/CuriousService.java
@@ -62,6 +62,12 @@ public class CuriousService {
         curiousRepository.deleteAllByPost(post);
     }
 
+    public void deleteAllByPosts(
+            final List<Post> posts
+    ) {
+        posts.forEach(post -> deleteAllByPost(post));
+    }
+
     public void deleteAllByWriterNameId(
             final Long writerNameId
     ) {

--- a/module-domain/src/main/java/com/mile/moim/service/MoimDeleteService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimDeleteService.java
@@ -1,0 +1,56 @@
+package com.mile.moim.service;
+
+import com.mile.comment.domain.Comment;
+import com.mile.comment.service.CommentService;
+import com.mile.commentreply.service.CommentReplyService;
+import com.mile.curious.service.CuriousService;
+import com.mile.moim.domain.Moim;
+import com.mile.moim.repository.MoimRepository;
+import com.mile.post.domain.Post;
+import com.mile.post.service.PostDeleteService;
+import com.mile.post.service.PostGetService;
+import com.mile.topic.domain.Topic;
+import com.mile.topic.service.TopicService;
+import com.mile.writername.service.WriterNameDeleteService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MoimDeleteService {
+
+    private final MoimService moimService;
+    private final TopicService topicService;
+    private final PostGetService postGetService;
+    private final CommentReplyService commentReplyService;
+    private final PostDeleteService postDeleteService;
+    private final CommentService commentService;
+    private final CuriousService curiousService;
+    private final MoimRepository moimRepository;
+    private final WriterNameDeleteService writerNameDeleteService;
+
+    @Transactional
+    public void deleteMoim(
+            final Long moimId,
+            final Long userId
+    ) {
+        moimService.getAuthenticateOwnerOfMoim(moimId, userId);
+        Moim moim = moimService.findById(moimId);
+        List<Topic> topics = topicService.findTopicListByMoimId(moimId);
+        List<Post> posts = postGetService.findAllByTopics(topics);
+        List<Comment> comments = commentService.findAllByPosts(posts);
+
+        commentReplyService.deleteRepliesByComments(comments);
+        commentService.deleteComments(comments);
+        curiousService.deleteAllByPosts(posts);
+        postDeleteService.deletePosts(posts);
+        topicService.deleteTopics(topics);
+        writerNameDeleteService.deleteWriterNamesByMoim(moim);
+        moimRepository.delete(moim);
+
+    }
+}

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -70,12 +70,8 @@ public class MoimService {
     private final MoimRepository moimRepository;
     private final PostDeleteService postDeleteService;
     private final PostAuthenticateService postAuthenticateService;
-    private final CommentReplyService commentReplyService;
-    private final CuriousService curiousService;
     private final PostGetService postGetService;
     private final SecureUrlUtil secureUrlUtil;
-    private final CommentService commentService;
-    private final WriterNameDeleteService writerNameDeleteService;
     private static final int WRITER_NAME_MAX_VALUE = 8;
     private static final int MOIM_NAME_MAX_VALUE = 10;
     private static final int BEST_MOIM_DEFAULT_NUMBER = 3;
@@ -255,7 +251,7 @@ public class MoimService {
         return topicService.getTopicListFromMoim(moimId, page);
     }
 
-    private void getAuthenticateOwnerOfMoim(
+    public void getAuthenticateOwnerOfMoim(
             final Long moimId,
             final Long userId
     ) {
@@ -366,24 +362,4 @@ public class MoimService {
         return MoimPublicStatusResponse.of(findById(moimId).isPublic());
     }
 
-    @Transactional
-    public void deleteMoim(
-            final Long moimId,
-            final Long userId
-    ) {
-        getAuthenticateOwnerOfMoim(moimId, userId);
-        Moim moim = findById(moimId);
-        List<Topic> topics = topicService.findTopicListByMoimId(moimId);
-        List<Post> posts = postGetService.findAllByTopics(topics);
-        List<Comment> comments = commentService.findAllByPosts(posts);
-
-        commentReplyService.deleteRepliesByComments(comments);
-        commentService.deleteComments(comments);
-        curiousService.deleteAllByPosts(posts);
-        postDeleteService.deletePosts(posts);
-        topicService.deleteTopics(topics);
-        writerNameDeleteService.deleteWriterNamesByMoim(moim);
-        moimRepository.delete(moim);
-
-    }
 }

--- a/module-domain/src/main/java/com/mile/post/service/PostDeleteService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostDeleteService.java
@@ -56,6 +56,12 @@ public class PostDeleteService {
         postRepository.delete(post);
     }
 
+    public void deletePosts(
+            final List<Post> posts
+    ) {
+        posts.forEach(post -> delete(post));
+    }
+
     private void deleteRelatedData(
             final Post post
     ) {

--- a/module-domain/src/main/java/com/mile/post/service/PostGetService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostGetService.java
@@ -81,4 +81,12 @@ public class PostGetService {
         return postRepository.countByWriterNameId(writerNameId);
     }
 
+    public List<Post> findAllByTopics(
+            final List<Topic> topics
+    ) {
+        return topics.stream()
+                .flatMap(topic -> postRepository.findByTopic(topic).stream())
+                .collect(Collectors.toList());
+    }
+
 }

--- a/module-domain/src/main/java/com/mile/topic/service/TopicService.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicService.java
@@ -92,7 +92,7 @@ public class TopicService {
         }
     }
 
-    private List<Topic> findTopicListByMoimId(
+    public List<Topic> findTopicListByMoimId(
             final Long moimId
     ) {
         return topicRepository.findByMoimId(moimId);
@@ -249,6 +249,12 @@ public class TopicService {
     ) {
         postGetService.findAllByTopic(topic)
                 .forEach(postDeleteService::delete);
+    }
+
+    public void deleteTopics(
+            final List<Topic> topics
+    ) {
+        topicRepository.deleteAll(topics);
     }
 }
 

--- a/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
+++ b/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
@@ -32,4 +32,6 @@ public interface WriterNameRepository extends JpaRepository<WriterName, Long> {
     List<WriterName> findAllByWriterId(final Long writerId);
 
     Integer countAllByWriter(final User user);
+
+    void deleteAllByMoim(final Moim moim);
 }

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameDeleteService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameDeleteService.java
@@ -4,6 +4,7 @@ import com.mile.comment.service.CommentService;
 import com.mile.curious.service.CuriousService;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.NotFoundException;
+import com.mile.moim.domain.Moim;
 import com.mile.moim.service.MoimService;
 import com.mile.post.service.PostDeleteService;
 import com.mile.writername.domain.WriterName;
@@ -43,5 +44,11 @@ public class WriterNameDeleteService {
         return writerNameRepository.findById(writerNameId).orElseThrow(
                 () -> new NotFoundException(ErrorMessage.WRITER_NOT_FOUND)
         );
+    }
+
+    public void deleteWriterNamesByMoim(
+            final Moim moim
+    ) {
+        writerNameRepository.deleteAllByMoim(moim);
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #385

## Key Changes 🔑
1. 내용
글모임 삭제 API 구현하였습니다!

## To Reviewers 📢

글모임 삭제는

1. 삭제 권한 확인
2. 해당 모임의 토픽 가져오기
3. 해당 토픽들의 글 가져오기
4. 해당 글들에 대한 댓글 가져오기
5. 해당 댓글들에 대한 대댓글 삭제
6. 해당 댓글들 삭제
7. 해당 글들 삭제
8. 해당 토픽들 삭제
9. 모임의 작가들 삭제
10. 해당 모임 삭제 

로 진행됩니다!