### PR TITLE
#386 [feat] 필명, 글모임명 중복체크 중 띄어쓰기 관련 로직 구현

### DIFF
--- a/module-domain/src/main/java/com/mile/moim/domain/Moim.java
+++ b/module-domain/src/main/java/com/mile/moim/domain/Moim.java
@@ -11,6 +11,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,6 +23,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(name = "moim", uniqueConstraints = @UniqueConstraint(columnNames = "normalizedName"))
 public class Moim extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,6 +32,7 @@ public class Moim extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private WriterName owner;
     private String name;
+    private String normalizedName;
     private String imageUrl;
     @Column(length = 500)
     private String information;
@@ -34,10 +40,17 @@ public class Moim extends BaseTimeEntity {
     private String idUrl;
     private boolean isPublic;
 
+    @PrePersist
+    @PreUpdate
+    public void normalizeName() {
+        this.normalizedName = this.name.replaceAll("\\s+", "").toLowerCase();
+    }
+
     public void modifyMoimInfo(
             final MoimInfoModifyRequest moimInfoModifyRequest
     ) {
         this.name = moimInfoModifyRequest.moimTitle();
+        this.normalizedName = this.name.replaceAll("\\s+", "").toLowerCase();
         if (moimInfoModifyRequest.imageUrl() != null) {
             this.imageUrl = moimInfoModifyRequest.imageUrl();
         }
@@ -53,6 +66,7 @@ public class Moim extends BaseTimeEntity {
             final boolean isPublic
     ) {
         this.name = name;
+        this.normalizedName = name.replaceAll("\\s+", "").toLowerCase();
         this.imageUrl = imageUrl;
         this.information = information;
         this.isPublic = isPublic;

--- a/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
+++ b/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
@@ -12,7 +12,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface MoimRepository extends JpaRepository<Moim, Long>, MoimRepositoryCustom {
     List<Post> getPostsById(final Long id);
-    Boolean existsByName(final String name);
+
+    @Query("SELECT CASE WHEN COUNT(m) > 0 THEN TRUE ELSE FALSE END FROM Moim m WHERE m.normalizedName = :name")
+    Boolean existsByName(@Param("name") String name);
 
     @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true AND p.createdAt BETWEEN :startOfWeek AND :endOfWeek GROUP BY m ORDER BY COUNT(p) DESC")
     List<Moim> findTop3PublicMoimsWithMostPostsLastWeek(Pageable pageable, @Param("startOfWeek") LocalDateTime startOfWeek, @Param("endOfWeek") LocalDateTime endOfWeek);

--- a/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
+++ b/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
@@ -13,8 +13,7 @@ import org.springframework.data.repository.query.Param;
 public interface MoimRepository extends JpaRepository<Moim, Long>, MoimRepositoryCustom {
     List<Post> getPostsById(final Long id);
 
-    @Query("SELECT CASE WHEN COUNT(m) > 0 THEN TRUE ELSE FALSE END FROM Moim m WHERE m.normalizedName = :name")
-    Boolean existsByName(@Param("name") String name);
+    Boolean existsByNormalizedName(final String normalizedName);
 
     @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true AND p.createdAt BETWEEN :startOfWeek AND :endOfWeek GROUP BY m ORDER BY COUNT(p) DESC")
     List<Moim> findTop3PublicMoimsWithMostPostsLastWeek(Pageable pageable, @Param("startOfWeek") LocalDateTime startOfWeek, @Param("endOfWeek") LocalDateTime endOfWeek);

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -266,6 +266,7 @@ public class MoimService {
         authenticateOwnerOfMoim(moim, userId);
     }
 
+
     public MoimNameConflictCheckResponse validateMoimName(
             final String moimName
     ) {

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -87,7 +87,8 @@ public class MoimService {
         if (writerName.length() > WRITER_NAME_MAX_VALUE) {
             throw new BadRequestException(ErrorMessage.WRITER_NAME_LENGTH_WRONG);
         }
-        return WriterNameConflictCheckResponse.of(writerNameService.existWriterNamesByMoimAndName(findById(moimId), writerName));
+        String normalizedWriterName = writerName.replaceAll("\\s+", "").toLowerCase();
+        return WriterNameConflictCheckResponse.of(writerNameService.existWriterNamesByMoimAndName(findById(moimId), normalizedWriterName));
     }
 
     public Long joinMoim(
@@ -268,10 +269,11 @@ public class MoimService {
     public MoimNameConflictCheckResponse validateMoimName(
             final String moimName
     ) {
+        String normalizedMoimName = moimName.replaceAll("\\s+", "").toLowerCase();
         if (moimName.length() > MOIM_NAME_MAX_VALUE) {
             throw new BadRequestException(ErrorMessage.MOIM_NAME_LENGTH_WRONG);
         }
-        return MoimNameConflictCheckResponse.of(!moimRepository.existsByName(moimName));
+        return MoimNameConflictCheckResponse.of(!moimRepository.existsByName(normalizedMoimName));
     }
 
     public InvitationCodeGetResponse getInvitationCode(

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -273,7 +273,7 @@ public class MoimService {
         if (moimName.length() > MOIM_NAME_MAX_VALUE) {
             throw new BadRequestException(ErrorMessage.MOIM_NAME_LENGTH_WRONG);
         }
-        return MoimNameConflictCheckResponse.of(!moimRepository.existsByName(normalizedMoimName));
+        return MoimNameConflictCheckResponse.of(!moimRepository.existsByNormalizedName(normalizedMoimName));
     }
 
     public InvitationCodeGetResponse getInvitationCode(

--- a/module-domain/src/main/java/com/mile/writername/domain/WriterName.java
+++ b/module-domain/src/main/java/com/mile/writername/domain/WriterName.java
@@ -10,6 +10,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,6 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(name = "writerName", uniqueConstraints = @UniqueConstraint(columnNames = "normalizedName"))
 public class WriterName {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,11 +32,18 @@ public class WriterName {
 
     private String name;
     private String information;
+    private String normalizedName;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private User writer;
 
     private Integer totalCuriousCount;
+
+    @PrePersist
+    @PreUpdate
+    public void normalizeName() {
+        this.normalizedName = this.name.replaceAll("\\s+", "").toLowerCase();
+    }
 
     public void increaseTotalCuriousCount() {
         totalCuriousCount++;
@@ -62,10 +74,12 @@ public class WriterName {
             final String name,
             final User user,
             final String information,
+            final String normalizedName,
             final int curiousCount
     ) {
         this.moim = moim;
         this.name = name;
+        this.normalizedName = normalizedName;
         this.writer = user;
         this.information = information;
         this.totalCuriousCount = curiousCount;
@@ -76,9 +90,11 @@ public class WriterName {
             final WriterMemberJoinRequest joinRequest,
             final User user
     ) {
+        String normalizedWriterName = joinRequest.writerName().replaceAll("\\s+", "").toLowerCase();
         return WriterName.builder()
                 .moim(moim)
                 .name(joinRequest.writerName())
+                .normalizedName(normalizedWriterName)
                 .information(joinRequest.writerDescription())
                 .user(user)
                 .curiousCount(0)

--- a/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
+++ b/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface WriterNameRepository extends JpaRepository<WriterName, Long> {
 
@@ -18,8 +20,8 @@ public interface WriterNameRepository extends JpaRepository<WriterName, Long> {
 
     List<WriterName> findByMoimId(final Long moimId);
 
-
-    boolean existsWriterNameByMoimAndName(final Moim moim, final String name);
+    @Query("SELECT CASE WHEN COUNT(w) > 0 THEN TRUE ELSE FALSE END FROM WriterName w WHERE w.moim = :moim AND w.normalizedName = :normalizedName")
+    boolean existsWriterNameByMoimAndName(@Param("moim") Moim moim, @Param("normalizedName") String normalizedName);
 
     Optional<WriterName> findByWriterId(final Long userId);
 

--- a/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
+++ b/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
@@ -20,8 +20,7 @@ public interface WriterNameRepository extends JpaRepository<WriterName, Long> {
 
     List<WriterName> findByMoimId(final Long moimId);
 
-    @Query("SELECT CASE WHEN COUNT(w) > 0 THEN TRUE ELSE FALSE END FROM WriterName w WHERE w.moim = :moim AND w.normalizedName = :normalizedName")
-    boolean existsWriterNameByMoimAndName(@Param("moim") Moim moim, @Param("normalizedName") String normalizedName);
+    boolean existsWriterNameByMoimAndNormalizedName(final Moim moim, final String normalizedName);
 
     Optional<WriterName> findByWriterId(final Long userId);
 

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -153,7 +153,7 @@ public class WriterNameService {
             final Moim moim,
             final String name
     ) {
-        return writerNameRepository.existsWriterNameByMoimAndName(moim, name);
+        return writerNameRepository.existsWriterNameByMoimAndNormalizedName(moim, name);
     }
 
     public WriterName findByWriterId(


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #386

## Key Changes 🔑
글모임과 필명 모두 "normalizedName"로 띄어쓰기를 제거하고, 대소문자를 소문자로 변경한 필드를 두었습니다.
글모임명, 필명 생성 과정에서 normalizedName 값을 저장하도록 하였고,
(현재 수정 로직이 있는 경우에 대해서는) normalizedName 값도 수정되도록 하였습니다.
현재 로직에서는 이렇게 normalizedName이 name과 함께 생성 및 변동될 수 있도록 하였지만 
데이터 무결성을 확실히 지킬 수 있는 방법을 찾아보았고 prepersist, preupdate 어노테이션을 적용해보았습니다.
엔티티가 db에 저장되기 전, 그리고 엔티티의 상태가 변경되어 데이터베이스에 업데이트되기 전에 호출되는 어노테이션입니다.
