### PR TITLE
#395 [refactor] Topic 관련 리팩토링

### DIFF
--- a/module-domain/src/main/java/com/mile/post/service/PostCreateService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostCreateService.java
@@ -3,6 +3,7 @@ package com.mile.post.service;
 import com.mile.post.domain.Post;
 import com.mile.post.repository.PostRepository;
 import com.mile.post.service.dto.TemporaryPostCreateRequest;
+import com.mile.topic.service.TopicRetriever;
 import com.mile.topic.service.TopicService;
 import com.mile.utils.SecureUrlUtil;
 import com.mile.writername.domain.WriterName;
@@ -15,7 +16,7 @@ import java.util.Base64;
 @RequiredArgsConstructor
 public class PostCreateService {
     private final PostRepository postRepository;
-    private final TopicService topicService;
+    private final TopicRetriever topicRetriever;
     private final SecureUrlUtil secureUrlUtil;
     private static final boolean TEMPORARY_TRUE = true;
     private static final String DEFAULT_IMG_URL = "https://mile-s3.s3.ap-northeast-2.amazonaws.com/test/groupMile.png";
@@ -30,7 +31,7 @@ public class PostCreateService {
             final TemporaryPostCreateRequest temporaryPostCreateRequest
     ) {
         Post post = postRepository.save(Post.create(
-                topicService.findById(secureUrlUtil.decodeUrl(temporaryPostCreateRequest.topicId())), // Topic
+                topicRetriever.findById(secureUrlUtil.decodeUrl(temporaryPostCreateRequest.topicId())), // Topic
                 writerName, // WriterName
                 temporaryPostCreateRequest.title(),
                 temporaryPostCreateRequest.content(),

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -19,6 +19,7 @@ import com.mile.post.service.dto.TemporaryPostCreateRequest;
 import com.mile.post.service.dto.TemporaryPostGetResponse;
 import com.mile.post.service.dto.WriterAuthenticateResponse;
 import com.mile.topic.domain.Topic;
+import com.mile.topic.service.TopicRetriever;
 import com.mile.topic.service.TopicService;
 import com.mile.topic.service.dto.ContentWithIsSelectedResponse;
 import com.mile.utils.SecureUrlUtil;
@@ -46,6 +47,7 @@ public class PostService {
     private final WriterNameService writerNameService;
     private final CuriousService curiousService;
     private final TopicService topicService;
+    private final TopicRetriever topicRetriever;
     private final PostDeleteService postDeleteService;
     private final SecureUrlUtil secureUrlUtil;
     private final PostCreateService postCreateService;
@@ -114,7 +116,7 @@ public class PostService {
     ) {
         Post post = postGetService.findById(postId);
         postAuthenticateService.authenticateWriter(postId, userId);
-        Topic topic = topicService.findById(decodeUrlToLong(putRequest.topicId()));
+        Topic topic = topicRetriever.findById(decodeUrlToLong(putRequest.topicId()));
         postUpdateService.update(post, topic, putRequest);
     }
 
@@ -123,7 +125,7 @@ public class PostService {
             final PostPutRequest putRequest
     ) {
         Post post = postGetService.findById(postId);
-        Topic topic = topicService.findById(decodeUrlToLong(putRequest.topicId()));
+        Topic topic = topicRetriever.findById(decodeUrlToLong(putRequest.topicId()));
         postUpdateService.update(post, topic, putRequest);
     }
 
@@ -210,7 +212,7 @@ public class PostService {
 
     private Post createPost(final PostCreateRequest postCreateRequest, final WriterName writerName) {
         return Post.create(
-                topicService.findById(decodeUrlToLong(postCreateRequest.topicId())), // Topic
+                topicRetriever.findById(decodeUrlToLong(postCreateRequest.topicId())), // Topic
                 writerName, // WriterName
                 postCreateRequest.title(),
                 postCreateRequest.content(),
@@ -228,7 +230,7 @@ public class PostService {
     ) {
         postAuthenticateService.authenticateWriterOfMoim(userId, decodeUrlToLong(temporaryPostCreateRequest.moimId()));
         WriterName writerName = writerNameService.findByMoimAndUser(secureUrlUtil.decodeUrl(temporaryPostCreateRequest.moimId()), userId);
-        postDeleteService.deleteTemporaryPosts(topicService.findById(secureUrlUtil.decodeUrl(temporaryPostCreateRequest.topicId())).getMoim(), writerName);
+        postDeleteService.deleteTemporaryPosts(topicRetriever.findById(secureUrlUtil.decodeUrl(temporaryPostCreateRequest.topicId())).getMoim(), writerName);
         postCreateService.createTemporaryPost(writerName, temporaryPostCreateRequest);
     }
 

--- a/module-domain/src/main/java/com/mile/topic/service/TopicCreator.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicCreator.java
@@ -1,0 +1,30 @@
+package com.mile.topic.service;
+
+import com.mile.moim.domain.Moim;
+import com.mile.moim.service.dto.TopicCreateRequest;
+import com.mile.topic.domain.Topic;
+import com.mile.topic.repository.TopicRepository;
+import com.mile.utils.SecureUrlUtil;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TopicCreator {
+
+    private final TopicRepository topicRepository;
+    private final SecureUrlUtil secureUrlUtil;
+
+    @Transactional
+    public Long createTopicOfMoim(
+            final Moim moim,
+            final TopicCreateRequest createRequest
+    ) {
+        Topic topic = topicRepository.saveAndFlush(Topic.create(moim, createRequest));
+        topic.setIdUrl(secureUrlUtil.encodeUrl(topic.getId()));
+        return topic.getId();
+    }
+}

--- a/module-domain/src/main/java/com/mile/topic/service/TopicCreator.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicCreator.java
@@ -7,11 +7,9 @@ import com.mile.topic.repository.TopicRepository;
 import com.mile.utils.SecureUrlUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
 @RequiredArgsConstructor
 public class TopicCreator {
 

--- a/module-domain/src/main/java/com/mile/topic/service/TopicRemover.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicRemover.java
@@ -25,27 +25,14 @@ public class TopicRemover {
     private final PostDeleteService postDeleteService;
     private final TopicRepository topicRepository;
 
-    @Transactional
     public void deleteTopic(
-            final Long userId,
-            final Long topicId
+            final Topic topic,
+            final User user
     ) {
-        Topic topic = topicRetriever.findById(topicId);
-        User user = userService.findById(userId);
-        topicRetriever.authenticateTopicWithUser(topic, user);
-        checkSingleTopicDeletion(topic);
-
         deletePostsOfTopic(topic);
         topicRepository.deleteById(topic.getId());
     }
 
-    private void checkSingleTopicDeletion(
-            final Topic topic
-    ) {
-        if (topicRepository.countByMoimId(topic.getMoim().getId()) <= 1) {
-            throw new BadRequestException(ErrorMessage.LEAST_TOPIC_SIZE_OF_MOIM_ERROR);
-        }
-    }
 
     private void deletePostsOfTopic(
             final Topic topic

--- a/module-domain/src/main/java/com/mile/topic/service/TopicRemover.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicRemover.java
@@ -1,15 +1,11 @@
 package com.mile.topic.service;
 
-import com.mile.exception.message.ErrorMessage;
-import com.mile.exception.model.BadRequestException;
 import com.mile.moim.domain.Moim;
 import com.mile.post.service.PostDeleteService;
 import com.mile.post.service.PostGetService;
 import com.mile.topic.domain.Topic;
 import com.mile.topic.repository.TopicRepository;
 import com.mile.user.domain.User;
-import com.mile.user.service.UserService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -19,8 +15,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TopicRemover {
 
-    private final TopicRetriever topicRetriever;
-    private final UserService userService;
     private final PostGetService postGetService;
     private final PostDeleteService postDeleteService;
     private final TopicRepository topicRepository;

--- a/module-domain/src/main/java/com/mile/topic/service/TopicRemover.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicRemover.java
@@ -1,0 +1,63 @@
+package com.mile.topic.service;
+
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.BadRequestException;
+import com.mile.moim.domain.Moim;
+import com.mile.post.service.PostDeleteService;
+import com.mile.post.service.PostGetService;
+import com.mile.topic.domain.Topic;
+import com.mile.topic.repository.TopicRepository;
+import com.mile.user.domain.User;
+import com.mile.user.service.UserService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TopicRemover {
+
+    private final TopicRetriever topicRetriever;
+    private final UserService userService;
+    private final PostGetService postGetService;
+    private final PostDeleteService postDeleteService;
+    private final TopicRepository topicRepository;
+
+    @Transactional
+    public void deleteTopic(
+            final Long userId,
+            final Long topicId
+    ) {
+        Topic topic = topicRetriever.findById(topicId);
+        User user = userService.findById(userId);
+        topicRetriever.authenticateTopicWithUser(topic, user);
+        checkSingleTopicDeletion(topic);
+
+        deletePostsOfTopic(topic);
+        topicRepository.deleteById(topic.getId());
+    }
+
+    private void checkSingleTopicDeletion(
+            final Topic topic
+    ) {
+        if (topicRepository.countByMoimId(topic.getMoim().getId()) <= 1) {
+            throw new BadRequestException(ErrorMessage.LEAST_TOPIC_SIZE_OF_MOIM_ERROR);
+        }
+    }
+
+    private void deletePostsOfTopic(
+            final Topic topic
+    ) {
+        postGetService.findAllByTopic(topic)
+                .forEach(postDeleteService::delete);
+    }
+
+    public void deleteTopicsByMoim(
+            final Moim moim
+    ) {
+        topicRepository.deleteByMoim(moim);
+    }
+
+}

--- a/module-domain/src/main/java/com/mile/topic/service/TopicRemover.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicRemover.java
@@ -7,11 +7,9 @@ import com.mile.topic.domain.Topic;
 import com.mile.topic.repository.TopicRepository;
 import com.mile.user.domain.User;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
 @RequiredArgsConstructor
 public class TopicRemover {
 

--- a/module-domain/src/main/java/com/mile/topic/service/TopicRetriever.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicRetriever.java
@@ -27,7 +27,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -35,7 +34,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
 @RequiredArgsConstructor
 public class TopicRetriever {
 

--- a/module-domain/src/main/java/com/mile/topic/service/TopicRetriever.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicRetriever.java
@@ -1,0 +1,195 @@
+package com.mile.topic.service;
+
+import com.mile.comment.service.CommentService;
+import com.mile.config.BaseTimeEntity;
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.ForbiddenException;
+import com.mile.exception.model.NotFoundException;
+import com.mile.moim.domain.Moim;
+import com.mile.moim.service.dto.MoimTopicInfoListResponse;
+import com.mile.moim.service.dto.MoimTopicInfoResponse;
+import com.mile.post.domain.Post;
+import com.mile.post.service.PostGetService;
+import com.mile.post.service.dto.PostListResponse;
+import com.mile.topic.domain.Topic;
+import com.mile.topic.repository.TopicRepository;
+import com.mile.topic.service.dto.ContentResponse;
+import com.mile.topic.service.dto.ContentWithIsSelectedResponse;
+import com.mile.topic.service.dto.PostListInTopicResponse;
+import com.mile.topic.service.dto.TopicDetailResponse;
+import com.mile.topic.service.dto.TopicOfMoimResponse;
+import com.mile.topic.service.dto.TopicResponse;
+import com.mile.user.domain.User;
+import com.mile.user.service.UserService;
+import com.mile.utils.SecureUrlUtil;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TopicRetriever {
+
+    private static final int TOPIC_PER_PAGE_SIZE = 4;
+
+    private final TopicRepository topicRepository;
+    private final PostGetService postGetService;
+    private final SecureUrlUtil secureUrlUtil;
+    private final CommentService commentService;
+    private final UserService userService;
+
+
+    public void authenticateTopicWithUser(
+            final Topic topic,
+            final User user
+    ) {
+        if (!topic.getMoim().getOwner().getWriter().equals(user)) {
+            throw new ForbiddenException(ErrorMessage.MOIM_OWNER_AUTHENTICATION_ERROR);
+        }
+    }
+
+    public Topic findById(
+            final Long topicId
+    ) {
+        return topicRepository.findById(topicId)
+                .orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.TOPIC_NOT_FOUND)
+                );
+    }
+
+    public List<Topic> sortByCreatedAt(
+            final List<Topic> topicList
+    ) {
+        return topicList.stream()
+                .sorted(Comparator.comparing(BaseTimeEntity::getCreatedAt).reversed())
+                .collect(Collectors.toList());
+    }
+
+    public PostListInTopicResponse getPostListByTopic(
+            final Long topicId,
+            final String lastPostId
+    ) {
+        Topic topic = findById(topicId);
+        Slice<Post> posts = postGetService.findByTopicAndLastPostId(topic, secureUrlUtil.decodeIfNotNull(lastPostId));
+        return PostListInTopicResponse.of(TopicOfMoimResponse.of(topic),
+                posts.stream().sorted(Comparator.comparing(BaseTimeEntity::getCreatedAt).reversed())
+                        .map(p -> PostListResponse.of(p, commentService.countByPost(p))).toList(),
+                posts.hasNext()
+        );
+    }
+
+    public TopicDetailResponse getTopicDetail(
+            final Long userId,
+            final Long topicId
+    ) {
+        Topic topic = findById(topicId);
+        authenticateTopicWithUser(topic, userService.findById(userId));
+        return TopicDetailResponse.of(topic);
+    }
+
+    public Long getNumberOfTopicFromMoim(
+            final Long moimId
+    ) {
+        return topicRepository.countByMoimId(moimId);
+    }
+
+    public MoimTopicInfoListResponse getTopicResponsesFromPage(Page<Topic> topicPage, final Long moimId) {
+        List<MoimTopicInfoResponse> infoResponses = topicPage.getContent()
+                .stream()
+                .map(MoimTopicInfoResponse::of)
+                .collect(Collectors.toList());
+
+        return MoimTopicInfoListResponse.of(
+                topicPage.getTotalPages(),
+                getNumberOfTopicFromMoim(moimId),
+                infoResponses
+        );
+    }
+
+    public MoimTopicInfoListResponse getTopicListFromMoim(
+            final Long moimId,
+            final int page
+    ) {
+
+        PageRequest pageRequest = PageRequest.of(page - 1, TOPIC_PER_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Topic> topicPage = topicRepository.findByMoimIdOrderByCreatedAtDesc(moimId, pageRequest);
+
+        isContentsEmpty(topicPage.getContent());
+
+        return getTopicResponsesFromPage(topicPage, moimId);
+    }
+
+    private void isContentsEmpty(
+            final List<Topic> topicList
+    ) {
+        if (topicList.isEmpty()) {
+            throw new NotFoundException(ErrorMessage.CONTENT_NOT_FOUND);
+        }
+    }
+
+    private void checkKeywordsEmpty(
+            final List<Topic> topicList
+    ) {
+        if (topicList.isEmpty()) {
+            throw new NotFoundException(ErrorMessage.KEYWORD_NOT_FOUND);
+        }
+    }
+
+    public List<ContentResponse> getContentsFromMoim(
+            final Long moimId
+    ) {
+        List<Topic> topicList = sortByCreatedAt(findTopicListByMoimId(moimId));
+        isContentsEmpty(topicList);
+        return topicList
+                .stream()
+                .map(ContentResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    public List<Topic> findTopicListByMoimId(
+            final Long moimId
+    ) {
+        return topicRepository.findByMoimId(moimId);
+    }
+
+    public List<TopicResponse> getKeywordsFromMoim(
+            final Long moimId
+    ) {
+        List<Topic> topicList = findTopicListByMoimId(moimId);
+        checkKeywordsEmpty(topicList);
+        return topicList
+                .stream()
+                .sorted(Comparator.comparing(BaseTimeEntity::getCreatedAt).reversed())
+                .map(TopicResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    public String findLatestTopicByMoim(
+            final Moim moim
+    ) {
+        return topicRepository.findLatestTopicByMoim(moim)
+                .orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.MOIM_TOPIC_NOT_FOUND)
+                );
+    }
+
+    public List<ContentWithIsSelectedResponse> getContentsWithIsSelectedFromMoim(
+            final Long moimId,
+            final Long selectedTopicId
+    ) {
+        List<Topic> topicList = sortByCreatedAt(findTopicListByMoimId(moimId));
+        isContentsEmpty(topicList);
+
+        return topicList.stream()
+                .map(topic -> ContentWithIsSelectedResponse.of(topic, topic.getId().equals(selectedTopicId)))
+                .collect(Collectors.toList());
+    }
+}

--- a/module-domain/src/main/java/com/mile/topic/service/TopicRetriever.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicRetriever.java
@@ -3,6 +3,7 @@ package com.mile.topic.service;
 import com.mile.comment.service.CommentService;
 import com.mile.config.BaseTimeEntity;
 import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.BadRequestException;
 import com.mile.exception.model.ForbiddenException;
 import com.mile.exception.model.NotFoundException;
 import com.mile.moim.domain.Moim;
@@ -191,5 +192,13 @@ public class TopicRetriever {
         return topicList.stream()
                 .map(topic -> ContentWithIsSelectedResponse.of(topic, topic.getId().equals(selectedTopicId)))
                 .collect(Collectors.toList());
+    }
+
+    public void checkSingleTopicDeletion(
+            final Topic topic
+    ) {
+        if (topicRepository.countByMoimId(topic.getMoim().getId()) <= 1) {
+            throw new BadRequestException(ErrorMessage.LEAST_TOPIC_SIZE_OF_MOIM_ERROR);
+        }
     }
 }

--- a/module-domain/src/main/java/com/mile/topic/service/TopicService.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicService.java
@@ -10,12 +10,14 @@ import com.mile.topic.service.dto.PostListInTopicResponse;
 import com.mile.topic.service.dto.TopicDetailResponse;
 import com.mile.topic.service.dto.TopicPutRequest;
 import com.mile.topic.service.dto.TopicResponse;
-import com.mile.topic.service.dto.TopicUpdator;
+import com.mile.user.domain.User;
+import com.mile.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +27,8 @@ public class TopicService {
     private final TopicRemover topicRemover;
     private final TopicUpdator topicUpdator;
     private final TopicCreator topicCreator;
+    private final UserService userService;
+
 
     public List<ContentResponse> getContentsFromMoim(
             final Long moimId
@@ -95,11 +99,16 @@ public class TopicService {
         return topicCreator.createTopicOfMoim(moim, createRequest);
     }
 
+    @Transactional
     public void deleteTopic(
             final Long userId,
             final Long topicId
     ) {
-        topicRemover.deleteTopic(userId, topicId);
+        Topic topic = topicRetriever.findById(topicId);
+        User user = userService.findById(userId);
+        topicRetriever.authenticateTopicWithUser(topic, user);
+        topicRetriever.checkSingleTopicDeletion(topic);
+        topicRemover.deleteTopic(topic, user);
     }
 
     public void putTopic(

--- a/module-domain/src/main/java/com/mile/topic/service/TopicService.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicService.java
@@ -1,260 +1,120 @@
 package com.mile.topic.service;
 
-import com.mile.comment.service.CommentService;
-import com.mile.config.BaseTimeEntity;
-import com.mile.exception.message.ErrorMessage;
-import com.mile.exception.model.BadRequestException;
-import com.mile.exception.model.ForbiddenException;
-import com.mile.exception.model.NotFoundException;
 import com.mile.moim.domain.Moim;
 import com.mile.moim.service.dto.MoimTopicInfoListResponse;
-import com.mile.moim.service.dto.MoimTopicInfoResponse;
 import com.mile.moim.service.dto.TopicCreateRequest;
-import com.mile.post.domain.Post;
-import com.mile.post.service.PostDeleteService;
-import com.mile.post.service.PostGetService;
-import com.mile.post.service.dto.PostListResponse;
 import com.mile.topic.domain.Topic;
-import com.mile.topic.repository.TopicRepository;
 import com.mile.topic.service.dto.ContentResponse;
 import com.mile.topic.service.dto.ContentWithIsSelectedResponse;
 import com.mile.topic.service.dto.PostListInTopicResponse;
 import com.mile.topic.service.dto.TopicDetailResponse;
-import com.mile.topic.service.dto.TopicOfMoimResponse;
 import com.mile.topic.service.dto.TopicPutRequest;
 import com.mile.topic.service.dto.TopicResponse;
-import com.mile.user.domain.User;
-import com.mile.user.service.UserService;
-import com.mile.utils.SecureUrlUtil;
-import jakarta.transaction.Transactional;
+import com.mile.topic.service.dto.TopicUpdator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class TopicService {
 
-    private static final int TOPIC_PER_PAGE_SIZE = 4;
-
-    private final TopicRepository topicRepository;
-    private final CommentService commentService;
-    private final UserService userService;
-    private final PostGetService postGetService;
-    private final SecureUrlUtil secureUrlUtil;
-    private final PostDeleteService postDeleteService;
+    private final TopicRetriever topicRetriever;
+    private final TopicRemover topicRemover;
+    private final TopicUpdator topicUpdator;
+    private final TopicCreator topicCreator;
 
     public List<ContentResponse> getContentsFromMoim(
             final Long moimId
     ) {
-        List<Topic> topicList = sortByCreatedAt(findTopicListByMoimId(moimId));
-        isContentsEmpty(topicList);
-        return topicList
-                .stream()
-                .map(ContentResponse::of)
-                .collect(Collectors.toList());
-    }
-
-    private void authenticateTopicWithUser(
-            final Topic topic,
-            final User user
-    ) {
-        if (!topic.getMoim().getOwner().getWriter().equals(user)) {
-            throw new ForbiddenException(ErrorMessage.MOIM_OWNER_AUTHENTICATION_ERROR);
-        }
+        return topicRetriever.getContentsFromMoim(moimId);
     }
 
     public List<ContentWithIsSelectedResponse> getContentsWithIsSelectedFromMoim(
             final Long moimId,
             final Long selectedTopicId
     ) {
-        List<Topic> topicList = sortByCreatedAt(findTopicListByMoimId(moimId));
-        isContentsEmpty(topicList);
-
-        return topicList.stream()
-                .map(topic -> ContentWithIsSelectedResponse.of(topic, topic.getId().equals(selectedTopicId)))
-                .collect(Collectors.toList());
-    }
-
-
-    private void isContentsEmpty(
-            final List<Topic> topicList
-    ) {
-        if (topicList.isEmpty()) {
-            throw new NotFoundException(ErrorMessage.CONTENT_NOT_FOUND);
-        }
+        return topicRetriever.getContentsWithIsSelectedFromMoim(moimId, selectedTopicId);
     }
 
     public List<Topic> findTopicListByMoimId(
             final Long moimId
     ) {
-        return topicRepository.findByMoimId(moimId);
-    }
-
-    private List<Topic> sortByCreatedAt(
-            final List<Topic> topicList
-    ) {
-        return topicList.stream()
-                .sorted(Comparator.comparing(BaseTimeEntity::getCreatedAt).reversed())
-                .collect(Collectors.toList());
-    }
-
-    public Topic findById(
-            final Long topicId
-    ) {
-        return topicRepository.findById(topicId)
-                .orElseThrow(
-                        () -> new NotFoundException(ErrorMessage.TOPIC_NOT_FOUND)
-                );
+        return topicRetriever.findTopicListByMoimId(moimId);
     }
 
     public List<TopicResponse> getKeywordsFromMoim(
             final Long moimId
     ) {
-        List<Topic> topicList = findTopicListByMoimId(moimId);
-        checkKeywordsEmpty(topicList);
-        return topicList
-                .stream()
-                .sorted(Comparator.comparing(BaseTimeEntity::getCreatedAt).reversed())
-                .map(TopicResponse::of)
-                .collect(Collectors.toList());
-    }
-
-    private void checkKeywordsEmpty(
-            final List<Topic> topicList
-    ) {
-        if (topicList.isEmpty()) {
-            throw new NotFoundException(ErrorMessage.KEYWORD_NOT_FOUND);
-        }
+        return topicRetriever.getKeywordsFromMoim(moimId);
     }
 
     public String findLatestTopicByMoim(
             final Moim moim
     ) {
-        return topicRepository.findLatestTopicByMoim(moim)
-                .orElseThrow(
-                        () -> new NotFoundException(ErrorMessage.MOIM_TOPIC_NOT_FOUND)
-                );
+        return topicRetriever.findLatestTopicByMoim(moim);
     }
 
     public PostListInTopicResponse getPostListByTopic(
             final Long topicId,
             final String lastPostId
     ) {
-        Topic topic = findById(topicId);
-        Slice<Post> posts = postGetService.findByTopicAndLastPostId(topic, secureUrlUtil.decodeIfNotNull(lastPostId));
-        return PostListInTopicResponse.of(TopicOfMoimResponse.of(topic),
-                posts.stream().sorted(Comparator.comparing(BaseTimeEntity::getCreatedAt).reversed())
-                        .map(p -> PostListResponse.of(p, commentService.countByPost(p))).toList(),
-                posts.hasNext()
-        );
+        return topicRetriever.getPostListByTopic(topicId, lastPostId);
     }
-
 
     public MoimTopicInfoListResponse getTopicListFromMoim(
             final Long moimId,
             final int page
     ) {
-
-        PageRequest pageRequest = PageRequest.of(page - 1, TOPIC_PER_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<Topic> topicPage = topicRepository.findByMoimIdOrderByCreatedAtDesc(moimId, pageRequest);
-
-        isContentsEmpty(topicPage.getContent());
-
-        return getTopicResponsesFromPage(topicPage, moimId);
+        return topicRetriever.getTopicListFromMoim(moimId, page);
     }
 
     public MoimTopicInfoListResponse getTopicResponsesFromPage(Page<Topic> topicPage, final Long moimId) {
-        List<MoimTopicInfoResponse> infoResponses = topicPage.getContent()
-                .stream()
-                .map(MoimTopicInfoResponse::of)
-                .collect(Collectors.toList());
-
-        return MoimTopicInfoListResponse.of(
-                topicPage.getTotalPages(),
-                getNumberOfTopicFromMoim(moimId),
-                infoResponses
-        );
+        return topicRetriever.getTopicResponsesFromPage(topicPage, moimId);
     }
 
     public Long getNumberOfTopicFromMoim(
             final Long moimId
     ) {
-        return topicRepository.countByMoimId(moimId);
+        return topicRetriever.getNumberOfTopicFromMoim(moimId);
     }
 
     public TopicDetailResponse getTopicDetail(
             final Long userId,
             final Long topicId
     ) {
-        Topic topic = findById(topicId);
-        authenticateTopicWithUser(topic, userService.findById(userId));
-        return TopicDetailResponse.of(topic);
+        return topicRetriever.getTopicDetail(userId, topicId);
     }
 
-    @Transactional
     public Long createTopicOfMoim(
             final Moim moim,
             final TopicCreateRequest createRequest
     ) {
-        Topic topic = topicRepository.saveAndFlush(Topic.create(moim, createRequest));
-        topic.setIdUrl(secureUrlUtil.encodeUrl(topic.getId()));
-        return topic.getId();
+        return topicCreator.createTopicOfMoim(moim, createRequest);
     }
 
-    @Transactional
     public void deleteTopic(
             final Long userId,
             final Long topicId
     ) {
-        Topic topic = findById(topicId);
-        User user = userService.findById(userId);
-        authenticateTopicWithUser(topic, user);
-        checkSingleTopicDeletion(topic);
-
-        deletePostsOfTopic(topic);
-        topicRepository.deleteById(topic.getId());
+        topicRemover.deleteTopic(userId, topicId);
     }
 
-    @Transactional
     public void putTopic(
             final Long userId,
             final Long topicId,
             final TopicPutRequest topicPutRequest
     ) {
-        Topic topic = findById(topicId);
-        User user = userService.findById(userId);
-        authenticateTopicWithUser(topic, user);
-        topic.updateTopic(topicPutRequest);
-    }
-
-
-    private void checkSingleTopicDeletion(
-            final Topic topic
-    ) {
-        if (topicRepository.countByMoimId(topic.getMoim().getId()) <= 1) {
-            throw new BadRequestException(ErrorMessage.LEAST_TOPIC_SIZE_OF_MOIM_ERROR);
-        }
-    }
-
-    private void deletePostsOfTopic(
-            final Topic topic
-    ) {
-        postGetService.findAllByTopic(topic)
-                .forEach(postDeleteService::delete);
+        topicUpdator.putTopic(userId, topicId, topicPutRequest);
     }
 
     public void deleteTopicsByMoim(
             final Moim moim
     ) {
-        topicRepository.deleteByMoim(moim);
+        topicRemover.deleteTopicsByMoim(moim);
     }
+
 }
 

--- a/module-domain/src/main/java/com/mile/topic/service/TopicUpdator.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicUpdator.java
@@ -6,11 +6,9 @@ import com.mile.user.domain.User;
 import com.mile.user.service.UserService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
 @RequiredArgsConstructor
 public class TopicUpdator {
 

--- a/module-domain/src/main/java/com/mile/topic/service/TopicUpdator.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicUpdator.java
@@ -1,7 +1,8 @@
-package com.mile.topic.service.dto;
+package com.mile.topic.service;
 
 import com.mile.topic.domain.Topic;
 import com.mile.topic.service.TopicRetriever;
+import com.mile.topic.service.dto.TopicPutRequest;
 import com.mile.user.domain.User;
 import com.mile.user.service.UserService;
 import jakarta.transaction.Transactional;

--- a/module-domain/src/main/java/com/mile/topic/service/TopicUpdator.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicUpdator.java
@@ -1,7 +1,6 @@
 package com.mile.topic.service;
 
 import com.mile.topic.domain.Topic;
-import com.mile.topic.service.TopicRetriever;
 import com.mile.topic.service.dto.TopicPutRequest;
 import com.mile.user.domain.User;
 import com.mile.user.service.UserService;

--- a/module-domain/src/main/java/com/mile/topic/service/dto/TopicUpdator.java
+++ b/module-domain/src/main/java/com/mile/topic/service/dto/TopicUpdator.java
@@ -1,0 +1,33 @@
+package com.mile.topic.service.dto;
+
+import com.mile.topic.domain.Topic;
+import com.mile.topic.service.TopicRetriever;
+import com.mile.user.domain.User;
+import com.mile.user.service.UserService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TopicUpdator {
+
+    private final TopicRetriever topicRetriever;
+    private final UserService userService;
+
+
+    @Transactional
+    public void putTopic(
+            final Long userId,
+            final Long topicId,
+            final TopicPutRequest topicPutRequest
+    ) {
+        Topic topic = topicRetriever.findById(topicId);
+        User user = userService.findById(userId);
+        topicRetriever.authenticateTopicWithUser(topic, user);
+        topic.updateTopic(topicPutRequest);
+    }
+
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #395 

## Key Changes 🔑

 TopicService를 TopicRetriever, TopicUpdator, TopicRemover, TopicCreator 로 분리 하여 리팩토링하였습니다!!


## To Reviewers 📢

topicService의 findById 를 topicRetriever로 이동하였는데요, 아래와 같은 고민이 있습니다!

기존에 다른 서비스에서 (postService 등) 에서 topicService의 findById를 호출하고 있었는데요, 이 경우 아래 두가지 방안 중 고민이 됩니다

1.  TopicService에서 TopicRetriever의 findById 호출
즉, topicService에 findById 메서드를 유지하되, topicRetriever의 findById 메서드를 호출한다. -> 이 경우, 다른 서비스에서 findById를 호출할 경우, topicService를 통해 호출한다.

2. TopicRetriever의 findById만 유지
즉, topicService에서 findById 메서드를 삭제하고, topicRetriever의 findById 메서드만 유지한다. -> 이 경우, 다른 서비스에서 findById 를 호출할 경우, topicRetriever를 통해 호출한다.

1번의 장점은 다른 서비스가 모두 topicService를 통해 가도록 단일 진입점을 유지할 수 있고,
topicRetriever를 변경할일이 생겨도 다른 서비스들에 영향을 미치지 않을수 있다.. 는 장점이 있는데요
그리고 순환참조 문제를 완벽히 방지하려면 1번 안이 더 맞지 않나 라는 생각이 드네요

중간 레이어가 하나 있다는 생각에 일단 2번으로 구현을 하였으나, 갈수록 1번이 맞지 않나 라는 생각이 들어서 의견을 여쭤봅니다!

