### PR TITLE
#426 [refactor] 사용자 글모임 list 조회 N+1 해결

### DIFF
--- a/module-domain/src/main/java/com/mile/user/service/UserService.java
+++ b/module-domain/src/main/java/com/mile/user/service/UserService.java
@@ -6,7 +6,6 @@ import com.mile.moim.service.dto.MoimOfUserResponse;
 import com.mile.user.domain.User;
 import com.mile.writername.service.WriterNameRemover;
 import com.mile.writername.service.WriterNameRetriever;
-import com.mile.writername.service.WriterNameService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
+++ b/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
@@ -32,7 +32,7 @@ public interface WriterNameRepository extends JpaRepository<WriterName, Long> {
 
     Optional<WriterName> findById(final Long id);
 
-    //@Query("select w from WriterName w join fetch w.moim where w.writer.id = :writerId")
+    @Query("select w from WriterName w join fetch w.moim where w.writer.id = :writerId")
     List<WriterName> findAllByWriterId(final Long writerId);
 
     Integer countAllByWriter(final User user);

--- a/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
+++ b/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -31,6 +32,7 @@ public interface WriterNameRepository extends JpaRepository<WriterName, Long> {
 
     Optional<WriterName> findById(final Long id);
 
+    //@Query("select w from WriterName w join fetch w.moim where w.writer.id = :writerId")
     List<WriterName> findAllByWriterId(final Long writerId);
 
     Integer countAllByWriter(final User user);

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameRetriever.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameRetriever.java
@@ -87,7 +87,7 @@ public class WriterNameRetriever {
     ) {
         return writerNameRepository.findAllByWriterId(userId)
                 .stream()
-                .map(writerName -> writerName.getMoim())
+                .map(WriterName::getMoim)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #426 

## Key Changes 🔑
1. 기존 findAll 후 moim을 받아오는 작업에서 발생하던 N+1문제를 fetch Join을 사용하므로써 해결하였습니다. 
--- 해결 전 (최대 6번의 쿼리 진행(유저를 찾아오는 질의 + 모임 개수 마다 select moim 하는 질의)
![image](https://github.com/Mile-Writings/Mile-Server/assets/79795051/96a927b3-fddd-4716-80fd-12403fe5411b)

--- 해결 후 (최대 1번의 쿼리 진행 -> fetch join으로 모든 moim 값 받아옴)
![Screenshot 2024-07-09 at 9 40 11 PM](https://github.com/Mile-Writings/Mile-Server/assets/79795051/dc57c1b5-699b-46cf-b5fb-148298a43dfe)
## To Reviewers 📢
-
