### PR TITLE
#447 [feat] 글 상세 뷰 에러 코드 세분화

### DIFF
--- a/module-api/src/main/java/com/mile/common/utils/ContextHolderUtil.java
+++ b/module-api/src/main/java/com/mile/common/utils/ContextHolderUtil.java
@@ -25,7 +25,8 @@ public class ContextHolderUtil {
         if (HttpMethod.OPTIONS.matches(servletRequest.getMethod())) {
             return null;
         }
-        String token = servletRequest.getHeader("Authorization");
+
+        final String token = servletRequest.getHeader("Authorization");
 
         if(!jwtTokenProvider.validateToken(token).equals(JwtValidationType.VALID_JWT)) {
             throw new UnauthorizedException(ErrorMessage.TOKEN_VALIDATION_ERROR);

--- a/module-api/src/main/java/com/mile/controller/comment/CommentController.java
+++ b/module-api/src/main/java/com/mile/controller/comment/CommentController.java
@@ -8,8 +8,8 @@ import com.mile.common.resolver.reply.ReplyIdPathVariable;
 import com.mile.common.resolver.user.UserId;
 import com.mile.dto.SuccessResponse;
 import com.mile.exception.message.SuccessMessage;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@Slf4j
 @RequestMapping("/api/comment")
 @RequiredArgsConstructor
 public class CommentController implements CommentControllerSwagger {
@@ -41,13 +40,14 @@ public class CommentController implements CommentControllerSwagger {
     public ResponseEntity<SuccessResponse> createCommentReply(
             @CommentIdPathVariable final Long commentId,
             @UserId final Long userId,
-            @RequestBody final ReplyCreateRequest createRequest,
+            @Valid @RequestBody final ReplyCreateRequest createRequest,
             @PathVariable("commentId") final String commentUrl
     ) {
         return ResponseEntity.status(HttpStatus.CREATED).header("Location",
                 commentService.createCommentReply(
                         userId,
-                        commentId, createRequest
+                        commentId,
+                        createRequest
                 )).body(SuccessResponse.of(SuccessMessage.REPLY_CREATE_SUCCESS));
     }
 

--- a/module-api/src/main/java/com/mile/controller/comment/CommentControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/comment/CommentControllerSwagger.java
@@ -11,13 +11,11 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Comment", description = "댓글 관련 API")
-@SecurityRequirement(name = "JWT Auth")
 public interface CommentControllerSwagger {
 
     @Operation(description = "댓글 삭제 API")

--- a/module-api/src/main/java/com/mile/controller/user/UserController.java
+++ b/module-api/src/main/java/com/mile/controller/user/UserController.java
@@ -28,7 +28,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserController implements UserControllerSwagger {
 
-    private final UserService userService;
     private final AuthFacade authFacade;
     private final static int COOKIE_MAX_AGE = 7 * 24 * 60 * 60;
     private final static String REFRESH_TOKEN = "refreshToken";
@@ -88,7 +87,7 @@ public class UserController implements UserControllerSwagger {
     public ResponseEntity<SuccessResponse<MoimListOfUserResponse>> getMoimListOfUser(
             @UserId final Long userId
     ) {
-        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_LIST_OF_USER_GET_SUCCESS, userService.getMoimOfUserList(userId)));
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_LIST_OF_USER_GET_SUCCESS, authFacade.getMoimListOfUser(userId)));
     }
 }
 

--- a/module-api/src/main/java/com/mile/controller/user/facade/AuthFacade.java
+++ b/module-api/src/main/java/com/mile/controller/user/facade/AuthFacade.java
@@ -7,6 +7,7 @@ import com.mile.common.auth.JwtTokenProvider;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.UnauthorizedException;
 import com.mile.jwt.service.TokenService;
+import com.mile.moim.service.dto.MoimListOfUserResponse;
 import com.mile.strategy.LoginStrategyManager;
 import com.mile.strategy.dto.UserInfoResponse;
 import com.mile.user.service.UserService;
@@ -103,5 +104,9 @@ public class AuthFacade {
                 jwtTokenProvider.issueAccessToken(id),
                 refreshToken
         );
+    }
+
+    public MoimListOfUserResponse getMoimListOfUser(long userId) {
+        return userService.getMoimOfUserList(userId);
     }
 }

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -72,7 +72,7 @@ public enum ErrorMessage {
     WRITER_AUTHENTICATE_ERROR(40302, "해당 사용자는 글 생성/수정/삭제 권한이 없습니다."),
     MOIM_OWNER_AUTHENTICATION_ERROR(HttpStatus.FORBIDDEN.value(), "사용자는 해당 모임의 모임장이 아닙니다."),
     WRITER_NAME_INFO_FORBIDDEN(HttpStatus.FORBIDDEN.value(), "해당 사용자는 필명에 접근 권한이 없습니다."),
-    COMMENT_ACCESS_ERROR(40306, "해당 사용자는 댓글에 접근 권한이 없습니다."),
+    COMMENT_ACCESS_ERROR(40305, "해당 사용자는 댓글에 접근 권한이 없습니다."),
     /*
     Method Not Supported
      */

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -13,12 +13,12 @@ public enum ErrorMessage {
      */
     USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 유저는 존재하지 않습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 유저의 리프레시 토큰이 존재하지 않습니다."),
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글은 존재하지 않습니다."),
+    POST_NOT_FOUND(40402, "해당 글은 존재하지 않습니다."),
     MOIM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글모임이 존재하지 않습니다."),
     CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 모임의 주제가 존재하지 않습니다."),
     HANDLER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "요청하신 URL은 정보가 없습니다."),
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 댓글이 존재하지 않습니다."),
-    CURIOUS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 궁금해요는 존재하지 않습니다."),
+    COMMENT_NOT_FOUND(40406, "해당 댓글이 존재하지 않습니다."),
+    CURIOUS_NOT_FOUND(40407, "해당 궁금해요는 존재하지 않습니다."),
     TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글감이 존재하지 않습니다."),
     KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글모임의 글감 키워드가 존재하지 않습니다."),
     WRITERS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 모임의 작가가 요청한 개수 이상 존재하지 않습니다"),
@@ -28,7 +28,7 @@ public enum ErrorMessage {
     TOPIC_POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글감의 글이 존재하지 않습니다."),
     MOIM_POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 모임의 글이 존재하지 않습니다."),
     RANDOM_VALUE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "랜덤 글 이름을 생성하는데 실패했습니다."),
-    REPLY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Id에 해당하는 대댓글이 없습니다."),
+    REPLY_NOT_FOUND(40416, "Id에 해당하는 대댓글이 없습니다."),
     /*
     Bad Request
      */
@@ -37,6 +37,8 @@ public enum ErrorMessage {
     SOCIAL_TYPE_BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "로그인 요청이 유효하지 않습니다."),
     INVALID_BUCKET_PREFIX(HttpStatus.BAD_REQUEST.value(), "유효하지 않는 S3 버킷 디렉터리 이름입니다."),
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "요청 값이 유효하지 않습니다."),
+    VALIDATION_REQUEST_NULL_OR_BLANK_EXCEPTION(40005,"요청 값이 비어있습니다."),
+    VALIDATION_REQUEST_LENGTH_EXCEPTION(40006,"요청 값이 길이를 초과했습니다."),
     BEARER_LOST_ERROR(HttpStatus.BAD_REQUEST.value(), "토큰의 요청에 Bearer이 담겨 있지 않습니다."),
     POST_NOT_TEMPORARY_ERROR(HttpStatus.BAD_REQUEST.value(), "해당 글은 임시저장 글이 아닙니다."),
     POST_TEMPORARY_ERROR(HttpStatus.BAD_REQUEST.value(), "해당 글은 임시저장글입니다."),
@@ -53,7 +55,7 @@ public enum ErrorMessage {
     /*
     Conflict
      */
-    CURIOUS_ALREADY_EXISTS_EXCEPTION(HttpStatus.CONFLICT.value(), "'궁금해요'는 이미 존재합니다."),
+    CURIOUS_ALREADY_EXISTS_EXCEPTION(40900, "'궁금해요'는 이미 존재합니다."),
     WRITER_NAME_ALREADY_EXIST(HttpStatus.CONFLICT.value(), "이미 가입한 모임입니다."),
     /*
     Unauthorized
@@ -61,16 +63,16 @@ public enum ErrorMessage {
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED.value(), "액세스 토큰이 만료되었습니다."),
     TOKEN_INCORRECT_ERROR(HttpStatus.UNAUTHORIZED.value(), "리프레시 토큰이 유효하지 않습니다."),
     TOKEN_VALIDATION_ERROR(HttpStatus.UNAUTHORIZED.value(), "사용자 검증 토큰이 유효하지 않습니다."),
-    UN_LOGIN_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "로그인 후 진행해주세요."),
+    UN_LOGIN_EXCEPTION(40103, "로그인 후 진행해주세요."),
     /*
     Forbidden
      */
-    USER_AUTHENTICATE_ERROR(HttpStatus.FORBIDDEN.value(), "해당 사용자는 모임에 접근 권한이 없습니다."),
-    REPLY_USER_FORBIDDEN(HttpStatus.UNAUTHORIZED.value(), "사용자에게 해당 대댓글에 대한 권한이 없습니다."),
-    WRITER_AUTHENTICATE_ERROR(HttpStatus.FORBIDDEN.value(), "해당 사용자는 글 생성/수정/삭제 권한이 없습니다."),
+    USER_AUTHENTICATE_ERROR(40300, "해당 사용자는 모임에 접근 권한이 없습니다."),
+    REPLY_USER_FORBIDDEN(40301, "사용자에게 해당 대댓글에 대한 권한이 없습니다."),
+    WRITER_AUTHENTICATE_ERROR(40302, "해당 사용자는 글 생성/수정/삭제 권한이 없습니다."),
     MOIM_OWNER_AUTHENTICATION_ERROR(HttpStatus.FORBIDDEN.value(), "사용자는 해당 모임의 모임장이 아닙니다."),
     WRITER_NAME_INFO_FORBIDDEN(HttpStatus.FORBIDDEN.value(), "해당 사용자는 필명에 접근 권한이 없습니다."),
-    COMMENT_ACCESS_ERROR(HttpStatus.FORBIDDEN.value(), "해당 사용자는 댓글에 접근 권한이 없습니다."),
+    COMMENT_ACCESS_ERROR(40306, "해당 사용자는 댓글에 접근 권한이 없습니다."),
     /*
     Method Not Supported
      */
@@ -78,7 +80,7 @@ public enum ErrorMessage {
     /*
     Too Many Requests
      */
-    TOO_MANY_REQUESTS_EXCEPTION(HttpStatus.TOO_MANY_REQUESTS.value(),"요청이 중복되었습니다."),
+    TOO_MANY_REQUESTS_EXCEPTION(HttpStatus.TOO_MANY_REQUESTS.value(), "요청이 중복되었습니다."),
     /*
     Internal Server Error
      */

--- a/module-common/src/main/java/com/mile/handler/GlobalExceptionHandler.java
+++ b/module-common/src/main/java/com/mile/handler/GlobalExceptionHandler.java
@@ -71,8 +71,15 @@ public class GlobalExceptionHandler {
         FieldError fieldError = e.getBindingResult().getFieldError();
         if (fieldError == null)
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(ErrorMessage.VALIDATION_REQUEST_MISSING_EXCEPTION));
-        else
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), fieldError.getDefaultMessage()));
+
+        return switch (fieldError.getCode()) {
+            case "NotNull", "NotBlank" ->
+                    ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(ErrorMessage.VALIDATION_REQUEST_NULL_OR_BLANK_EXCEPTION));
+            case "Size" ->
+                    ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(ErrorMessage.VALIDATION_REQUEST_LENGTH_EXCEPTION));
+            default ->
+                    ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(ErrorMessage.VALIDATION_REQUEST_MISSING_EXCEPTION));
+        };
     }
 
     @ExceptionHandler(ForbiddenException.class)
@@ -95,7 +102,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(ErrorResponse.of(e.getErrorMessage()));
     }
 
-    @ExceptionHandler({NoHandlerFoundException.class})
+    @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(final NoHandlerFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of(ErrorMessage.HANDLER_NOT_FOUND));
     }

--- a/module-domain/src/main/java/com/mile/comment/domain/Comment.java
+++ b/module-domain/src/main/java/com/mile/comment/domain/Comment.java
@@ -4,6 +4,7 @@ import com.mile.config.BaseTimeEntity;
 import com.mile.post.domain.Post;
 import com.mile.post.service.dto.CommentCreateRequest;
 import com.mile.writername.domain.WriterName;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -30,6 +31,8 @@ public class Comment extends BaseTimeEntity {
     private Post post;
     @Setter
     private String idUrl;
+
+    @Column(length = 2000)
     private String content;
     private boolean anonymous;
 

--- a/module-domain/src/main/java/com/mile/comment/service/CommentRetriever.java
+++ b/module-domain/src/main/java/com/mile/comment/service/CommentRetriever.java
@@ -4,13 +4,13 @@ import com.mile.comment.domain.Comment;
 import com.mile.comment.repository.CommentRepository;
 import com.mile.commentreply.service.CommentReplyRetriever;
 import com.mile.exception.message.ErrorMessage;
-import com.mile.exception.model.ForbiddenException;
 import com.mile.exception.model.NotFoundException;
 import com.mile.post.domain.Post;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -42,13 +42,11 @@ public class CommentRetriever {
         return comment.getPost().getTopic().getMoim().getId();
     }
 
-    public void authenticateUser(
+    public boolean authenticateUserOfComment(
             final Comment comment,
             final Long userId
     ) {
-        if (!commentRepository.findUserIdByComment(comment).equals(userId)) {
-            throw new ForbiddenException(ErrorMessage.COMMENT_ACCESS_ERROR);
-        }
+        return commentRepository.findUserIdByComment(comment).equals(userId);
     }
 
     public Comment findById(

--- a/module-domain/src/main/java/com/mile/comment/service/CommentService.java
+++ b/module-domain/src/main/java/com/mile/comment/service/CommentService.java
@@ -5,6 +5,9 @@ import com.mile.comment.service.dto.CommentResponse;
 import com.mile.commentreply.service.CommentReplyRemover;
 import com.mile.commentreply.service.CommentReplyService;
 import com.mile.commentreply.service.dto.ReplyCreateRequest;
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.ForbiddenException;
+import com.mile.moim.service.MoimRetriever;
 import com.mile.post.domain.Post;
 import com.mile.post.service.PostRetriever;
 import com.mile.writername.service.WriterNameRetriever;
@@ -26,6 +29,7 @@ public class CommentService {
     private final CommentRetriever commentRetriever;
     private final CommentRemover commentRemover;
     private final CommentReplyRemover commentReplyRemover;
+    private final MoimRetriever moimRetriever;
 
 
     @Transactional
@@ -34,7 +38,10 @@ public class CommentService {
             final Long userId
     ) {
         Comment comment = commentRetriever.findById(commentId);
-        commentRetriever.authenticateUser(comment, userId);
+        if (commentRetriever.authenticateUserOfComment(comment, userId) &&
+                moimRetriever.isMoimOwnerEqualsUser(comment.getWriterName().getMoim(), userId)) {
+            throw new ForbiddenException(ErrorMessage.COMMENT_ACCESS_ERROR);
+        }
         commentReplyRemover.deleteRepliesByComment(comment);
         commentRemover.delete(comment);
     }
@@ -48,18 +55,20 @@ public class CommentService {
 
     public List<CommentResponse> getCommentResponse(
             final Long moimId,
-            final Long postId,
+            final Post post,
             final Long userId
     ) {
-        postRetriever.authenticateUserWithPostId(postId, userId);
-        List<Comment> commentList = commentRetriever.findByPostId(postId);
+        postRetriever.authenticateUserWithPostId(post.getId(), userId);
+        List<Comment> commentList = commentRetriever.findByPostId(post.getId());
         Long writerNameId = writerNameRetriever.getWriterNameIdByMoimIdAndUserId(moimId, userId);
+
         return commentList.stream()
                 .map(comment -> CommentResponse.of(
                         comment,
                         writerNameId,
-                        commentRetriever.isCommentWriterEqualWriterOfPost(comment, postRetriever.findById(postId)),
-                        commentReplyService.findRepliesByComment(comment, writerNameId))).collect(Collectors.toList());
+                        commentRetriever.isCommentWriterEqualWriterOfPost(comment, post),
+                        commentReplyService.findRepliesByComment(comment, writerNameId)))
+                .collect(Collectors.toList());
     }
 
     public String createCommentReply(
@@ -88,16 +97,6 @@ public class CommentService {
                 c -> result.addAndGet(commentReplyService.findRepliesCountByComment(c))
         );
         return result.intValue();
-    }
-
-    public List<Comment> findAllByPosts(
-            final List<Post> posts
-    ) {
-        return commentRetriever.findAllByPosts(posts);
-    }
-
-    public void deleteComments(final List<Post> posts) {
-        commentRemover.deleteComments(posts);
     }
 
 }

--- a/module-domain/src/main/java/com/mile/commentreply/domain/CommentReply.java
+++ b/module-domain/src/main/java/com/mile/commentreply/domain/CommentReply.java
@@ -2,6 +2,7 @@ package com.mile.commentreply.domain;
 
 import com.mile.comment.domain.Comment;
 import com.mile.writername.domain.WriterName;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -27,6 +28,7 @@ public class CommentReply {
     @Setter
     private String idUrl;
     private boolean isAnonymous;
+    @Column(length = 20000)
     private String content;
 
     @Builder

--- a/module-domain/src/main/java/com/mile/commentreply/service/CommentReplyRetriever.java
+++ b/module-domain/src/main/java/com/mile/commentreply/service/CommentReplyRetriever.java
@@ -7,8 +7,11 @@ import com.mile.commentreply.service.dto.ReplyResponse;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.NotFoundException;
 import com.mile.exception.model.UnauthorizedException;
+
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.mile.moim.service.MoimRetriever;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -40,17 +43,16 @@ public class CommentReplyRetriever {
             final Comment comment,
             final Long writerNameId
     ) {
-        return commentReplyRepository.findByComment(comment).stream().map(c -> ReplyResponse.of(c, writerNameId, isWriterOfPost(c))).collect(
-                Collectors.toList());
+        return commentReplyRepository.findByComment(comment).stream()
+                .map(commentReply -> ReplyResponse.of(commentReply, writerNameId, isWriterOfPost(commentReply)))
+                .collect(Collectors.toList());
     }
 
-    public void authenticateReplyWithUserId(
+    public boolean authenticateReplyWithUserId(
             final Long userId,
             final CommentReply commentReply
     ) {
-        if (!commentReply.getWriterName().getWriter().getId().equals(userId)) {
-            throw new UnauthorizedException(ErrorMessage.REPLY_USER_FORBIDDEN);
-        }
+        return commentReply.getWriterName().getWriter().getId().equals(userId);
     }
 
     public int countByWriterNameId(final Long writerNameId) {

--- a/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
+++ b/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
@@ -24,5 +24,5 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
     @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true GROUP BY m ORDER BY MAX(p.createdAt) DESC")
     List<Moim> findLatestMoimsWithoutExclusion(Pageable pageable);
 
-    Optional<Moim> findByOwner(@NonNull final WriterName writerName);
+    Optional<Moim> findByOwner(final WriterName writerName);
 }

--- a/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
+++ b/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
@@ -24,5 +24,5 @@ public interface MoimRepository extends JpaRepository<Moim, Long> {
     @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true GROUP BY m ORDER BY MAX(p.createdAt) DESC")
     List<Moim> findLatestMoimsWithoutExclusion(Pageable pageable);
 
-    Optional<Moim> findByOwner(final WriterName writerName);
+    Optional<Moim> findByOwner(@NonNull final WriterName writerName);
 }

--- a/module-domain/src/main/java/com/mile/moim/service/MoimRetriever.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimRetriever.java
@@ -11,6 +11,7 @@ import com.mile.writername.domain.WriterName;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
+import reactor.util.annotation.NonNull;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -34,16 +35,16 @@ public class MoimRetriever {
             final Moim moim,
             final User user
     ) {
-        if (!isMoimOwnerEqualsUser(moim, user)) {
+        if (!isMoimOwnerEqualsUser(moim, user.getId())) {
             throw new ForbiddenException(ErrorMessage.MOIM_OWNER_AUTHENTICATION_ERROR);
         }
     }
 
     public boolean isMoimOwnerEqualsUser(
             final Moim moim,
-            final User user
+            @NonNull final Long userId
     ) {
-        return moim.getOwner().getWriter().equals(user);
+        return moim.getOwner().getWriter().getId().equals(userId);
     }
 
     public List<Moim> findBestMoims() {
@@ -64,8 +65,8 @@ public class MoimRetriever {
 
 
     @AtomicValidateUniqueMoimName
-    public boolean checkNormalizeName(final String normalizedName) {
-        return moimRepository.existsByNormalizedName(normalizedName);
+    public boolean validateNormalizedName(final String normalizedName) {
+        return !moimRepository.existsByNormalizedName(normalizedName);
     }
 
     public Optional<Moim> findByOwner(final WriterName writerName) {

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -1,6 +1,5 @@
 package com.mile.moim.service;
 
-import com.mile.commentreply.service.CommentReplyRemover;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.BadRequestException;
 import com.mile.exception.model.ForbiddenException;
@@ -70,7 +69,7 @@ public class MoimService {
     private static final int WRITER_NAME_MAX_VALUE = 8;
     private static final int MOIM_NAME_MAX_VALUE = 10;
     private static final int BEST_MOIM_DEFAULT_NUMBER = 3;
-    private final CommentReplyRemover commentReplyRemover;
+
 
     public ContentListResponse getContentsFromMoim(
             final Long moimId,
@@ -125,7 +124,7 @@ public class MoimService {
             final Long moimId,
             final Long userId
     ) {
-        return MoimAuthenticateResponse.of(writerNameRetriever.isUserInMoim(moimId, userId), moimRetriever.isMoimOwnerEqualsUser(moimRetriever.findById(moimId), userRetriever.findById(userId)));
+        return MoimAuthenticateResponse.of(writerNameRetriever.isUserInMoim(moimId, userId), moimRetriever.isMoimOwnerEqualsUser(moimRetriever.findById(moimId), userId));
     }
 
     public PopularWriterListResponse getMostCuriousWritersOfMoim(
@@ -243,7 +242,7 @@ public class MoimService {
         if (moimName.length() > MOIM_NAME_MAX_VALUE) {
             throw new BadRequestException(ErrorMessage.MOIM_NAME_VALIDATE_ERROR);
         }
-        return MoimNameConflictCheckResponse.of(moimRetriever.checkNormalizeName(normalizedMoimName));
+        return MoimNameConflictCheckResponse.of(moimRetriever.validateNormalizedName(normalizedMoimName));
     }
 
 
@@ -251,7 +250,7 @@ public class MoimService {
     public void checkMoimNameUnique(
             final String moimName
     ) {
-        if (moimRetriever.checkNormalizeName(moimName)) {
+        if (moimRetriever.validateNormalizedName(moimName)) {
             throw new BadRequestException(ErrorMessage.MOIM_NAME_VALIDATE_ERROR);
         }
     }

--- a/module-domain/src/main/java/com/mile/post/service/PostRetriever.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostRetriever.java
@@ -71,6 +71,7 @@ public class PostRetriever {
     ) {
         return postRepository.findByTopic(topic);
     }
+
     private List<Post> getPostHaveCuriousCount(
             final List<Post> postList
     ) {
@@ -114,19 +115,21 @@ public class PostRetriever {
             final Long postId,
             final Long writerNameId
     ) {
-        if(!existsPostByWriterWithPost(postId, writerNameId)) {
+        if (!existsPostByWriterWithPost(postId, writerNameId)) {
             throw new ForbiddenException(ErrorMessage.WRITER_AUTHENTICATE_ERROR);
         }
     }
 
-    public WriterName authenticateWriter(
+    public void authenticateWriter(
             final Long postId,
             final WriterName writerName
     ) {
         authenticateWriterWithPost(postId, writerName.getId());
-        return writerName;
     }
 
+    public boolean isWriterOfPost(final Post post, final WriterName writerName) {
+        return post.getWriterName().equals(writerName);
+    }
 
     public void authenticateWriterOfMoim(
             final Long userId,

--- a/module-domain/src/main/java/com/mile/post/service/PostService.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostService.java
@@ -66,7 +66,7 @@ public class PostService {
 
     ) {
         Post post = postRetriever.findById(postId);
-        Long moimId = post.getTopic().getMoim().getId();
+        final Long moimId = post.getTopic().getMoim().getId();
         postRetriever.authenticateUserOfMoim(writerNameRetriever.isUserInMoim(moimId, userId));
         commentCreator.createComment(post, writerNameRetriever.findByMoimAndUser(moimId, userId), commentCreateRequest);
     }
@@ -88,7 +88,7 @@ public class PostService {
             final Long userId
     ) {
         Post post = postRetriever.findById(postId);
-        return CommentListResponse.of(commentService.getCommentResponse(post.getTopic().getMoim().getId(), postId, userId));
+        return CommentListResponse.of(commentService.getCommentResponse(post.getTopic().getMoim().getId(), post, userId));
     }
 
     @Transactional(readOnly = true)
@@ -154,9 +154,8 @@ public class PostService {
             final Long userId
     ) {
         Post post = postRetriever.findById(postId);
-        Long moimId = getMoimIdFromPostId(postId);
-        postRetriever.authenticateWriter(postId,
-                writerNameRetriever.findWriterNameByMoimIdAndUserId(moimId, userId));
+        Long moimId = post.getTopic().getMoim().getId();
+        postRetriever.authenticateWriter(postId, writerNameRetriever.findWriterNameByMoimIdAndUserId(moimId, userId));
         postRemover.delete(post);
     }
 

--- a/module-domain/src/main/java/com/mile/post/service/dto/PostCreateRequest.java
+++ b/module-domain/src/main/java/com/mile/post/service/dto/PostCreateRequest.java
@@ -17,12 +17,12 @@ public record PostCreateRequest(
         String topicId,
 
         @NotBlank(message = "제목을 입력해주세요.")
-        @Size(max = 29, message = "제목 최대 글자를 초과했습니다.")
+        @Size(max = 34, message = "제목 최대 글자를 초과했습니다.")
         @Schema(description = "글 제목", example = "편안한 글쓰기")
         String title,
 
         @NotBlank(message = "내용을 입력해주세요.")
-        @Size(max = 2500, message = "내용 최대 글자를 초과했습니다.")
+        @Size(max = 10000, message = "내용 최대 글자를 초과했습니다.")
         @Schema(description = "글 내용", example = "내용입니다.")
         String content,
 

--- a/module-domain/src/main/java/com/mile/writername/domain/WriterName.java
+++ b/module-domain/src/main/java/com/mile/writername/domain/WriterName.java
@@ -18,11 +18,12 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import reactor.util.annotation.NonNull;
 
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "writerName", uniqueConstraints = @UniqueConstraint(columnNames = "normalizedName"))
+@Table(name = "writer_name", uniqueConstraints = @UniqueConstraint(columnNames = "normalized_name"))
 public class WriterName {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -49,6 +50,12 @@ public class WriterName {
 
     public void increaseTotalCuriousCount() {
         totalCuriousCount++;
+    }
+
+    @Override
+    public boolean equals(@NonNull final Object writerName) {
+        WriterName that = (WriterName) writerName;
+        return id.equals(that.getId());
     }
 
     public void decreaseTotalCuriousCount() {


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #447 

## Key Changes 🔑
(중요도 상)
1. 에러 코드 세분화 -> 글 상세 뷰에서 발생하는 예외 케이스들의 코드를 세분화 하였습니다.
2. 글 모임 뷰에서 글쓴이가 모두 글쓴이로 보이지 않던 현상을 해결했습니다. equals를 오버라이드 해서 재정의하면서 해결했습니다. 
- 제가 파악하기에는, 같은 영속성 컨텍스트에 존재하지 않는 이유로 equals가 제대로 작동하지 않은 것 같습니다 [링크](https://impati.github.io/posts/jpa-equals/)
3. 글 상세 뷰에서 방장에 대해 글 삭제, 댓글 대댓글 삭제 권한이 존재한다는 점을 발견하였습니다. 그래서 이 요구사항에 적합하게 수정하였습니다.
---
(중요도 하)
4. 이전에 반영되어 있지 않던, 댓글 대댓글 길이 관련한 DB 제약사항 변경했습니다.
5. WriterName테이블의 Constraints와 이름 명명이 카멜케이스가 아닌 다른 방법으로 적용되어 있어서 수정했습니다.

## To Reviewers 📢
- 변경사항이 큽니다! 이번 주까지 반영해야하니 리뷰 부탁드려요!
