### PR TITLE
#452 [feat] 관리자 페이지 멤버 관리 에러 코드 세분화

### DIFF
--- a/module-api/src/test/java/com/mile/controller/MoimControllerTest.java
+++ b/module-api/src/test/java/com/mile/controller/MoimControllerTest.java
@@ -9,6 +9,8 @@ import com.mile.moim.service.dto.MoimCreateRequest;
 import com.mile.moim.service.dto.MoimInfoModifyRequest;
 import com.mile.moim.service.dto.TopicCreateRequest;
 import com.mile.moim.service.dto.WriterMemberJoinRequest;
+import com.mile.post.service.PostService;
+import com.mile.post.service.dto.PostCreateRequest;
 import com.mile.user.domain.User;
 import com.mile.user.repository.UserRepository;
 import com.mile.utils.SecureUrlUtil;
@@ -55,6 +57,9 @@ public class MoimControllerTest {
     private MoimService moimService;
 
     @Autowired
+    private PostService postService;
+
+    @Autowired
     private ObjectMapper objectMapper;
 
     private static final String AUTHORIZATION = "Authorization";
@@ -81,6 +86,7 @@ public class MoimControllerTest {
     테스트 이전 더미 모임 쌓기
      */
     @Test
+    @Transactional
     @DisplayName("더미 모임 생성")
     public void bSaveNewMoimAndGetMoimId() {
         String randomTagString = UUID.randomUUID().toString().substring(0, 3);
@@ -95,7 +101,13 @@ public class MoimControllerTest {
                 randomTagString,
                 randomString
         );
+
+        TopicCreateRequest topicCreateRequest = new TopicCreateRequest(randomString, randomTagString, randomTagString);
         MOIM_ID = moimService.createMoim(USER_ID, createRequest).moimId();
+        String topicId = secureUrlUtil
+                .encodeUrl(Long.parseLong(moimService.createTopic(secureUrlUtil.decodeUrl(MOIM_ID), USER_ID, topicCreateRequest)));
+        PostCreateRequest postCreateRequest =new PostCreateRequest(MOIM_ID, topicId, randomString, randomString, randomString, false);
+        postService.createPost(USER_ID, postCreateRequest);
     }
 
     /*
@@ -435,7 +447,6 @@ public class MoimControllerTest {
 
     @Test
     @DisplayName("글모임이 정상적으로 삭제된다.")
-    @Transactional
     public void zdeleteMoimTest() throws Exception {
         //given
         String token = "Bearer " + jwtTokenProvider.issueAccessToken(USER_ID);

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -22,7 +22,7 @@ public enum ErrorMessage {
     TOPIC_NOT_FOUND(40408, "해당 글감이 존재하지 않습니다."),
     KEYWORD_NOT_FOUND(40409, "해당 글모임의 글감 키워드가 존재하지 않습니다."),
     WRITERS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 모임의 작가가 요청한 개수 이상 존재하지 않습니다"),
-    WRITER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 작가는 존재하지 않습니다."),
+    WRITER_NOT_FOUND(40411, "해당 작가는 존재하지 않습니다."),
     RECOMMEND_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "추천 글감을 받아오는데 실패했습니다."),
     MOIM_TOPIC_NOT_FOUND(40413, "해당 모임의 글감이 존재하지 않습니다."),
     TOPIC_POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글감의 글이 존재하지 않습니다."),
@@ -70,7 +70,7 @@ public enum ErrorMessage {
     USER_AUTHENTICATE_ERROR(40300, "해당 사용자는 모임에 접근 권한이 없습니다."),
     REPLY_USER_FORBIDDEN(40301, "사용자에게 해당 대댓글에 대한 권한이 없습니다."),
     WRITER_AUTHENTICATE_ERROR(40302, "해당 사용자는 글 생성/수정/삭제 권한이 없습니다."),
-    MOIM_OWNER_AUTHENTICATION_ERROR(HttpStatus.FORBIDDEN.value(), "사용자는 해당 모임의 모임장이 아닙니다."),
+    MOIM_OWNER_AUTHENTICATION_ERROR(40303, "사용자는 해당 모임의 모임장이 아닙니다."),
     WRITER_NAME_INFO_FORBIDDEN(HttpStatus.FORBIDDEN.value(), "해당 사용자는 필명에 접근 권한이 없습니다."),
     COMMENT_ACCESS_ERROR(40305, "해당 사용자는 댓글에 접근 권한이 없습니다."),
     /*

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -225,8 +225,12 @@ public class MoimService {
             final Long userId,
             final MoimInfoModifyRequest modifyRequest
     ) {
-        checkMoimNameUnique(modifyRequest.moimTitle());
         Moim moim = moimRetriever.findById(moimId);
+
+        if (!moim.getName().equals(modifyRequest.moimTitle())) {
+            validateMoimName(modifyRequest.moimTitle());
+        }
+
         moimRetriever.authenticateOwnerOfMoim(moim, userRetriever.findById(userId));
         moim.modifyMoimInfo(modifyRequest);
     }

--- a/module-domain/src/main/java/com/mile/topic/repository/TopicRepository.java
+++ b/module-domain/src/main/java/com/mile/topic/repository/TopicRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -22,6 +23,7 @@ public interface TopicRepository extends JpaRepository<Topic, Long>, TopicReposi
 
     Page<Topic> findByMoimIdOrderByCreatedAtDesc(Long moimId, Pageable pageable);
 
+    @Transactional
     @Modifying
     @Query("DELETE FROM Topic t where t.moim = :moim")
     void deleteByMoim(@Param("moim") Moim moim);

--- a/module-domain/src/main/java/com/mile/topic/service/TopicRemover.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicRemover.java
@@ -20,17 +20,10 @@ public class TopicRemover {
     private final TopicRepository topicRepository;
 
     public void deleteTopic(
-            final Topic topic,
-            final User user
+            final Topic topic
     ) {
         deletePostsOfTopic(topic);
         topicRepository.deleteById(topic.getId());
-    }
-
-    public void deleteTopics(
-            final List<Topic> topics
-    ) {
-
     }
 
     private void deletePostsOfTopic(

--- a/module-domain/src/main/java/com/mile/topic/service/TopicService.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicService.java
@@ -82,7 +82,7 @@ public class TopicService {
         User user = userService.findById(userId);
         topicRetriever.authenticateTopicWithUser(topic, user);
         topicRetriever.checkSingleTopicDeletion(topic);
-        topicRemover.deleteTopic(topic, user);
+        topicRemover.deleteTopic(topic);
     }
 
     public void putTopic(

--- a/module-domain/src/main/java/com/mile/topic/service/TopicService.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicService.java
@@ -27,7 +27,6 @@ public class TopicService {
     private final TopicCreator topicCreator;
     private final UserService userService;
 
-
     public List<ContentWithIsSelectedResponse> getContentsWithIsSelectedFromMoim(
             final Long moimId,
             final Long selectedTopicId
@@ -42,35 +41,11 @@ public class TopicService {
         return topicRetriever.getPostListByTopic(topicId, lastPostId);
     }
 
-    public MoimTopicInfoListResponse getTopicListFromMoim(
-            final Long moimId,
-            final int page
-    ) {
-        return topicRetriever.getTopicListFromMoim(moimId, page);
-    }
-
-    public MoimTopicInfoListResponse getTopicResponsesFromPage(Page<Topic> topicPage, final Long moimId) {
-        return topicRetriever.getTopicResponsesFromPage(topicPage, moimId);
-    }
-
-    public Long getNumberOfTopicFromMoim(
-            final Long moimId
-    ) {
-        return topicRetriever.getNumberOfTopicFromMoim(moimId);
-    }
-
     public TopicDetailResponse getTopicDetail(
             final Long userId,
             final Long topicId
     ) {
         return topicRetriever.getTopicDetail(userId, topicId);
-    }
-
-    public Long createTopicOfMoim(
-            final Moim moim,
-            final TopicCreateRequest createRequest
-    ) {
-        return topicCreator.createTopicOfMoim(moim, createRequest);
     }
 
     @Transactional


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #452 

## Key Changes 🔑
1. 관리자 페이지 멤버 관리 에러 코드 세분화하였습니다!
2. 관리자 페이지에서 글모임 정보 수정 시, 만약 글모임 이름 변경이 있을 시에만 validate문을 통과하게 진행했습니다.
3. 기존에 글모임 삭제 프로세스에서 batch query를 사용했는데, 이 때 `@Transactional`을 처리해주기 위해 (처리해주지 않아 에러가 발생했었습니다) 레포지토리 메서드에 붙였습니다.

## To Reviewers 📢
-
