### PR TITLE
#464 [feat] 필명 리스트 오름차순 정렬

### DIFF
--- a/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
+++ b/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
@@ -29,7 +29,9 @@ public interface WriterNameRepository extends JpaRepository<WriterName, Long> {
 
     List<WriterName> findTop2ByMoimIdAndTotalCuriousCountGreaterThanOrderByTotalCuriousCountDesc(final Long moimId, final int totalCuriousCount);
 
-    Page<WriterName> findByMoimIdOrderByIdAsc(Long moimId, Pageable pageable);
+    @Query("SELECT w FROM WriterName w WHERE w.moim.id = :moimId ORDER BY CASE WHEN w = :owner THEN 0 ELSE 1 END, w.id ASC")
+    Page<WriterName> findByMoimIdOrderByOwnerFirstAndIdAsc(@Param("moimId") Long moimId, @Param("owner") WriterName owner, Pageable pageable);
+
 
     Optional<WriterName> findById(final Long id);
 

--- a/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
+++ b/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
@@ -29,7 +29,7 @@ public interface WriterNameRepository extends JpaRepository<WriterName, Long> {
 
     List<WriterName> findTop2ByMoimIdAndTotalCuriousCountGreaterThanOrderByTotalCuriousCountDesc(final Long moimId, final int totalCuriousCount);
 
-    Page<WriterName> findByMoimIdOrderByIdDesc(Long moimId, Pageable pageable);
+    Page<WriterName> findByMoimIdOrderByIdAsc(Long moimId, Pageable pageable);
 
     Optional<WriterName> findById(final Long id);
 

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameRetriever.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameRetriever.java
@@ -112,6 +112,6 @@ public class WriterNameRetriever {
 
 
     public Page<WriterName> findWriterNameByMoimIdOrderByLatest(final Long moimId, final PageRequest pageRequest) {
-        return writerNameRepository.findByMoimIdOrderByIdDesc(moimId, pageRequest);
+        return writerNameRepository.findByMoimIdOrderByIdAsc(moimId, pageRequest);
     }
 }

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameRetriever.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameRetriever.java
@@ -111,7 +111,7 @@ public class WriterNameRetriever {
     }
 
 
-    public Page<WriterName> findWriterNameByMoimIdOrderByLatest(final Long moimId, final PageRequest pageRequest) {
-        return writerNameRepository.findByMoimIdOrderByIdAsc(moimId, pageRequest);
+    public Page<WriterName> findWriterNameByMoimIdOrderByOwnerFirstAndIdAsc(final Long moimId, final WriterName owner, final PageRequest pageRequest) {
+        return writerNameRepository.findByMoimIdOrderByOwnerFirstAndIdAsc(moimId, owner, pageRequest);
     }
 }

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -121,7 +121,7 @@ public class WriterNameService {
     ) {
         final Long moimId = moim.getId();
         PageRequest pageRequest = PageRequest.of(page - 1, WRITERNAME_PER_PAGE_SIZE, Sort.by(Sort.Direction.ASC, "id"));
-        Page<WriterName> writerNamePage = writerNameRetriever.findWriterNameByMoimIdOrderByLatest(moimId, pageRequest);
+        Page<WriterName> writerNamePage = writerNameRetriever.findWriterNameByMoimIdOrderByOwnerFirstAndIdAsc(moimId, moim.getOwner(), pageRequest);
         List<WriterNameInfoResponse> infoResponses = writerNamePage.getContent()
                 .stream()
                 .map(writerName -> WriterNameInfoResponse.of(writerName.getId(), writerName.getName(),

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameService.java
@@ -120,7 +120,7 @@ public class WriterNameService {
             final int page
     ) {
         final Long moimId = moim.getId();
-        PageRequest pageRequest = PageRequest.of(page - 1, WRITERNAME_PER_PAGE_SIZE, Sort.by(Sort.Direction.DESC, "id"));
+        PageRequest pageRequest = PageRequest.of(page - 1, WRITERNAME_PER_PAGE_SIZE, Sort.by(Sort.Direction.ASC, "id"));
         Page<WriterName> writerNamePage = writerNameRetriever.findWriterNameByMoimIdOrderByLatest(moimId, pageRequest);
         List<WriterNameInfoResponse> infoResponses = writerNamePage.getContent()
                 .stream()


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #464 

## Key Changes 🔑
1. 내용
 필명 리스트를 writername id 기준 오름차순 정렬로 변경했습니다. 
 글모임장이 제일 먼저 오도록 쿼리문을 수정하였습니다.


