### PR TITLE
#471 [feat] Refresh Token 이용 방식 수정

### DIFF
--- a/module-api/src/main/java/com/mile/controller/user/UserController.java
+++ b/module-api/src/main/java/com/mile/controller/user/UserController.java
@@ -4,17 +4,21 @@ import com.mile.client.dto.UserLoginRequest;
 import com.mile.common.resolver.user.UserId;
 import com.mile.controller.user.facade.AuthFacade;
 import com.mile.dto.SuccessResponse;
+import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.message.SuccessMessage;
+import com.mile.exception.model.BadRequestException;
 import com.mile.moim.service.dto.MoimListOfUserResponse;
 import com.mile.user.service.UserService;
 import com.mile.user.service.dto.AccessTokenGetSuccess;
 import com.mile.user.service.dto.LoginSuccessResponse;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController implements UserControllerSwagger {
 
     private final AuthFacade authFacade;
-    private final static int COOKIE_MAX_AGE = 7 * 24 * 60 * 60;
+    private final static Long COOKIE_MAX_AGE = 60 * 60 * 24 * 1000L * 14;
     private final static String REFRESH_TOKEN = "refreshToken";
 
     @PostMapping("/login")
@@ -56,8 +60,9 @@ public class UserController implements UserControllerSwagger {
     @Override
     public SuccessResponse<AccessTokenGetSuccess> refreshToken(
             @UserId Long userId,
-            @RequestParam final String refreshToken
+            @CookieValue(name = REFRESH_TOKEN) Cookie cookie
     ) {
+        String refreshToken = cookie.getValue();
         return SuccessResponse.of(SuccessMessage.ISSUE_ACCESS_TOKEN_SUCCESS, authFacade.refreshToken(userId, refreshToken));
     }
 

--- a/module-api/src/main/java/com/mile/controller/user/UserControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/user/UserControllerSwagger.java
@@ -14,8 +14,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -49,7 +51,7 @@ public interface UserControllerSwagger {
     )
     SuccessResponse<AccessTokenGetSuccess> refreshToken(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) @UserId Long userId,
-            @RequestParam final String refreshToken
+            @CookieValue Cookie cookie
     );
 
     @Operation(summary = "로그아웃")

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -21,13 +21,9 @@ public enum ErrorMessage {
     CURIOUS_NOT_FOUND(40407, "해당 궁금해요는 존재하지 않습니다."),
     TOPIC_NOT_FOUND(40408, "해당 글감이 존재하지 않습니다."),
     KEYWORD_NOT_FOUND(40409, "해당 글모임의 글감 키워드가 존재하지 않습니다."),
-    WRITERS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 모임의 작가가 요청한 개수 이상 존재하지 않습니다"),
     WRITER_NOT_FOUND(40411, "해당 작가는 존재하지 않습니다."),
     RECOMMEND_NOT_FOUND(40412, "추천 글감을 받아오는데 실패했습니다."),
     MOIM_TOPIC_NOT_FOUND(40413, "해당 모임의 글감이 존재하지 않습니다."),
-    TOPIC_POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 글감의 글이 존재하지 않습니다."),
-    MOIM_POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 모임의 글이 존재하지 않습니다."),
-    RANDOM_VALUE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "랜덤 글 이름을 생성하는데 실패했습니다."),
     REPLY_NOT_FOUND(40416, "Id에 해당하는 대댓글이 없습니다."),
     /*
     Bad Request
@@ -52,6 +48,7 @@ public enum ErrorMessage {
     WRITER_NAME_LENGTH_WRONG(HttpStatus.BAD_REQUEST.value(), "사용 불가능한 필명입니다."),
     MOIM_NAME_VALIDATE_ERROR(40018, "사용 불가능한 모임명입니다."),
     EXCEED_MOIM_MAX_SIZE(40019, "최대 가입 가능 모임 개수(5개)를 초과하였습니다."),
+    REFRESH_TOKEN_NULL(40020, "리프레시 토큰의 값이 비어있습니다."),
     /*
     Conflict
      */
@@ -61,8 +58,7 @@ public enum ErrorMessage {
     /*
     Unauthorized
      */
-    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED.value(), "액세스 토큰이 만료되었습니다."),
-    TOKEN_INCORRECT_ERROR(HttpStatus.UNAUTHORIZED.value(), "리프레시 토큰이 유효하지 않습니다."),
+    TOKEN_INCORRECT_ERROR(40101, "리프레시 토큰이 유효하지 않습니다."),
     TOKEN_VALIDATION_ERROR(40102, "사용자 검증 토큰이 유효하지 않습니다."),
     UN_LOGIN_EXCEPTION(40103, "로그인 후 진행해주세요."),
     /*


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #471 

## Key Changes 🔑
1. 기존 Refresh Token이 http only 속성 때문에 js에서 parameter로 전달하는 것이 불가능해서 Cookie를 사용하기로 했습니다!
2. 대신 Cookie의 만료시간을 늘렸습니다!

## To Reviewers 📢
-
