### PR TITLE
#486 [fix] 베스트모임 페이지 개수 변경

### DIFF
--- a/module-domain/src/main/java/com/mile/moim/service/MoimRetriever.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimRetriever.java
@@ -50,7 +50,7 @@ public class MoimRetriever {
     public List<Moim> findBestMoims() {
         LocalDateTime endOfWeek = LocalDateTime.now();
         LocalDateTime startOfWeek = endOfWeek.minusDays(7);
-        PageRequest pageRequest = PageRequest.of(0, 2);
+        PageRequest pageRequest = PageRequest.of(0, 3);
         return moimRepository.findTop3PublicMoimsWithMostPostsLastWeek(pageRequest, startOfWeek, endOfWeek);
     }
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #486

## Key Changes 🔑
1. 내용
베스트모임 리턴 에러가 PageRequest 개수를 잘못 입력하여 발생한 에러여서, 수를 변경했습니다 !
## To Reviewers 📢
-
