### PR TITLE
#501 [fix] best 글모임 받아올 때 임시저장 글 제외

### DIFF
--- a/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
+++ b/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
@@ -15,11 +15,11 @@ import java.util.Optional;
 public interface MoimRepository extends JpaRepository<Moim, Long> {
     Boolean existsByNormalizedName(final String normalizedName);
 
-    @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true AND p.createdAt BETWEEN :startOfWeek AND :endOfWeek GROUP BY m ORDER BY COUNT(p) DESC LIMIT 3")
-    List<Moim> findTop3PublicMoimsWithMostPostsLastWeek(Pageable pageable, @Param("startOfWeek") LocalDateTime startOfWeek, @Param("endOfWeek") LocalDateTime endOfWeek);
+    @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true AND p.isTemporary = false AND p.createdAt BETWEEN :startOfWeek AND :endOfWeek GROUP BY m ORDER BY COUNT(p)")
+    List<Moim> findTop3PublicMoimWithMostPostsLastWeek(final Pageable pageable, final @Param("startOfWeek") LocalDateTime startOfWeek, final @Param("endOfWeek") LocalDateTime endOfWeek);
 
-    @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true AND m NOT IN :excludeMoims GROUP BY m ORDER BY MAX(p.createdAt) DESC")
-    List<Moim> findLatestMoimsWithExclusion(Pageable pageable, @Param("excludeMoims") List<Moim> excludeMoims);
+    @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true AND p.isTemporary = false AND m NOT IN :excludeMoims GROUP BY m ORDER BY MAX(p.createdAt) DESC")
+    List<Moim> findLatestMoimWithExclusion(final Pageable pageable, final @Param("excludeMoims") List<Moim> excludeMoims);
 
     @Query("SELECT m FROM Post p JOIN p.topic t JOIN t.moim m WHERE m.isPublic = true GROUP BY m ORDER BY MAX(p.createdAt) DESC")
     List<Moim> findLatestMoimsWithoutExclusion(Pageable pageable);

--- a/module-domain/src/main/java/com/mile/moim/service/MoimRetriever.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimRetriever.java
@@ -51,7 +51,7 @@ public class MoimRetriever {
         LocalDateTime endOfWeek = LocalDateTime.now();
         LocalDateTime startOfWeek = endOfWeek.minusDays(7);
         PageRequest pageRequest = PageRequest.of(0, 3);
-        return moimRepository.findTop3PublicMoimsWithMostPostsLastWeek(pageRequest, startOfWeek, endOfWeek);
+        return moimRepository.findTop3PublicMoimWithMostPostsLastWeek(pageRequest, startOfWeek, endOfWeek);
     }
 
     public List<Moim> getLatestMoims(int count, List<Moim> excludeMoims) {
@@ -59,7 +59,7 @@ public class MoimRetriever {
         if (excludeMoims.isEmpty()) {
             return moimRepository.findLatestMoimsWithoutExclusion(pageRequest);
         } else {
-            return moimRepository.findLatestMoimsWithExclusion(pageRequest, excludeMoims);
+            return moimRepository.findLatestMoimWithExclusion(pageRequest, excludeMoims);
         }
     }
 

--- a/module-domain/src/main/java/com/mile/post/repository/PostRepositoryCustom.java
+++ b/module-domain/src/main/java/com/mile/post/repository/PostRepositoryCustom.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface PostRepositoryCustom {
     List<Post> findTop2ByMoimOrderByCuriousCountDesc(final Moim requestMoim);
 
-    List<Post> findLatest4NonTemporaryPostsByMoim(Moim moim);
+    List<Post> findLatest4NonTemporaryPostsByMoim(final Moim moim);
 
     Optional<Post> findByMoimAndWriterNameWhereIsTemporary(final Moim moim, final WriterName writerName);
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #501 

## Key Changes 🔑
1. best 글모임을 받아올 때 빈 글모임이 오는 것을 확인하였습니다!
 - 임시 저장글에 대해서도 counting을 하고 있었기 때문이라는 점을 발견했습니다. 그래서 이에 대해 수정을 진행했습니다
 - 그리고 Pageable을 넘기면 limit 3 이 필요 없어서 이를 지워주었습니다!
## To Reviewers 📢
-
