### PR TITLE
#504 [feat] 글모임 정보 통합 제공 API 구현

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -15,6 +15,9 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    //Sentry
+    implementation 'io.sentry:sentry-spring-boot-starter-jakarta:7.9.0'
 }
 
 tasks.named('test') {

--- a/module-api/src/main/java/com/mile/controller/moim/MoimController.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimController.java
@@ -21,13 +21,16 @@ import com.mile.moim.service.dto.response.MoimPublicStatusResponse;
 import com.mile.moim.service.dto.response.MoimTopicInfoListResponse;
 import com.mile.moim.service.dto.response.MoimTopicResponse;
 import com.mile.moim.service.dto.response.MoimWriterNameListGetResponse;
-import com.mile.moim.service.dto.response.PopularWriterListResponse;
+import com.mile.moim.service.dto.response.MoimMostCuriousWriterResponse;
 import com.mile.moim.service.dto.response.TemporaryPostExistResponse;
 import com.mile.moim.service.dto.request.TopicCreateRequest;
 import com.mile.moim.service.dto.response.TopicListResponse;
 import com.mile.moim.service.dto.request.WriterMemberJoinRequest;
 import com.mile.moim.service.dto.response.WriterNameConflictCheckResponse;
 import com.mile.writername.service.dto.response.WriterNameShortResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -43,6 +46,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.concurrent.ExecutionException;
 
 @RestController
 @RequiredArgsConstructor
@@ -112,7 +116,7 @@ public class MoimController implements MoimControllerSwagger {
 
     @Override
     @GetMapping("/{moimId}/writers/top-rank")
-    public ResponseEntity<SuccessResponse<PopularWriterListResponse>> getMostCuriousWritersOfMoim(
+    public ResponseEntity<SuccessResponse<MoimMostCuriousWriterResponse>> getMostCuriousWritersOfMoim(
             @MoimIdPathVariable final Long moimId,
             @PathVariable("moimId") final String moimUrl
     ) {
@@ -293,4 +297,12 @@ public class MoimController implements MoimControllerSwagger {
         return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_DELETE_SUCCESS));
     }
 
+    @Override
+    @GetMapping("/{moimId}/information")
+    public ResponseEntity<SuccessResponse> getMoimTotalInformation(
+            @MoimIdPathVariable @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long moimId,
+            @PathVariable("moimId") final String moimUrl
+    ) {
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.MOIM_INFO_SUCCESS, moimService.getMoimTotalInformation(moimId)));
+    }
 }

--- a/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
+++ b/module-api/src/main/java/com/mile/controller/moim/MoimControllerSwagger.java
@@ -18,7 +18,7 @@ import com.mile.moim.service.dto.response.MoimNameConflictCheckResponse;
 import com.mile.moim.service.dto.response.MoimTopicInfoListResponse;
 import com.mile.moim.service.dto.response.MoimTopicResponse;
 import com.mile.moim.service.dto.response.MoimWriterNameListGetResponse;
-import com.mile.moim.service.dto.response.PopularWriterListResponse;
+import com.mile.moim.service.dto.response.MoimMostCuriousWriterResponse;
 import com.mile.moim.service.dto.response.TemporaryPostExistResponse;
 import com.mile.moim.service.dto.request.TopicCreateRequest;
 import com.mile.moim.service.dto.response.TopicListResponse;
@@ -85,7 +85,7 @@ public interface MoimControllerSwagger {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
-    ResponseEntity<SuccessResponse<PopularWriterListResponse>> getMostCuriousWritersOfMoim(
+    ResponseEntity<SuccessResponse<MoimMostCuriousWriterResponse>> getMostCuriousWritersOfMoim(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long moimId,
             @PathVariable("moimId") final String moimUrl
     );
@@ -428,6 +428,20 @@ public interface MoimControllerSwagger {
     ResponseEntity<SuccessResponse> deleteMoim(
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long moimId,
             @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) @UserId final Long userId,
+            @PathVariable("moimId") final String moimUrl
+    );
+
+    @Operation(summary = "글모임 정보, 가장 궁금한 글, 가장 궁금한 작가")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "글모임의 개괄적인 정보가 조회되었습니다."),
+                    @ApiResponse(responseCode = "404", description = "해당 모임은 존재하지 않습니다."),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    ResponseEntity<SuccessResponse> getMoimTotalInformation(
+            @Parameter(schema = @Schema(implementation = String.class), in = ParameterIn.PATH) final Long moimId,
             @PathVariable("moimId") final String moimUrl
     );
 }

--- a/module-api/src/main/java/com/mile/controller/user/facade/AuthFacade.java
+++ b/module-api/src/main/java/com/mile/controller/user/facade/AuthFacade.java
@@ -17,7 +17,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthFacade {
 
     private final UserService userService;

--- a/module-api/src/main/java/com/mile/exception/handler/GlobalExceptionHandler.java
+++ b/module-api/src/main/java/com/mile/exception/handler/GlobalExceptionHandler.java
@@ -70,7 +70,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(final HttpRequestMethodNotSupportedException e) {
-        Sentry.captureException(e);
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(ErrorResponse.of(ErrorMessage.METHOD_NOT_SUPPORTED));
     }
 
@@ -117,7 +116,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(final NoHandlerFoundException e) {
-        Sentry.captureException(e);
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of(ErrorMessage.HANDLER_NOT_FOUND));
     }
 

--- a/module-api/src/main/java/com/mile/exception/handler/GlobalExceptionHandler.java
+++ b/module-api/src/main/java/com/mile/exception/handler/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.mile.handler;
+package com.mile.exception.handler;
 
 import com.mile.dto.ErrorResponse;
 import com.mile.exception.message.ErrorMessage;

--- a/module-api/src/main/java/com/mile/exception/log/discord/DiscordAppender.java
+++ b/module-api/src/main/java/com/mile/exception/log/discord/DiscordAppender.java
@@ -1,13 +1,13 @@
-package com.mile.log.discord;
+package com.mile.exception.log.discord;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
-import com.mile.log.discord.exception.ErrorLogAppenderException;
-import com.mile.log.discord.model.EmbedObject;
-import com.mile.log.utils.MDCUtil;
-import com.mile.log.utils.StringUtil;
+import com.mile.exception.log.discord.exception.ErrorLogAppenderException;
+import com.mile.exception.log.discord.model.EmbedObject;
+import com.mile.exception.log.utils.MDCUtil;
+import com.mile.exception.log.utils.StringUtil;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringEscapeUtils;

--- a/module-api/src/main/java/com/mile/exception/log/discord/DiscordWebHook.java
+++ b/module-api/src/main/java/com/mile/exception/log/discord/DiscordWebHook.java
@@ -1,15 +1,15 @@
-package com.mile.log.discord;
+package com.mile.exception.log.discord;
 
 
-import com.mile.log.discord.exception.ErrorLogAppenderException;
-import com.mile.log.discord.model.Author;
-import com.mile.log.discord.model.EmbedObject;
-import com.mile.log.discord.model.Field;
-import com.mile.log.discord.model.Footer;
-import com.mile.log.discord.model.Image;
-import com.mile.log.discord.model.JsonObject;
-import com.mile.log.discord.model.Thumbnail;
-import com.mile.log.utils.ApiCallUtil;
+import com.mile.exception.log.discord.exception.ErrorLogAppenderException;
+import com.mile.exception.log.discord.model.Author;
+import com.mile.exception.log.discord.model.EmbedObject;
+import com.mile.exception.log.discord.model.Field;
+import com.mile.exception.log.discord.model.Footer;
+import com.mile.exception.log.discord.model.JsonObject;
+import com.mile.exception.log.discord.model.Thumbnail;
+import com.mile.exception.log.utils.ApiCallUtil;
+import com.mile.exception.log.discord.model.Image;
 
 import java.awt.Color;
 import java.io.IOException;

--- a/module-api/src/main/java/com/mile/exception/log/discord/exception/ErrorLogAppenderException.java
+++ b/module-api/src/main/java/com/mile/exception/log/discord/exception/ErrorLogAppenderException.java
@@ -1,4 +1,4 @@
-package com.mile.log.discord.exception;
+package com.mile.exception.log.discord.exception;
 
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.MileException;

--- a/module-api/src/main/java/com/mile/exception/log/discord/model/Author.java
+++ b/module-api/src/main/java/com/mile/exception/log/discord/model/Author.java
@@ -1,12 +1,13 @@
-package com.mile.log.discord.model;
+package com.mile.exception.log.discord.model;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class Footer {
+public class Author {
 
-    private final String text;
+    private final String name;
+    private final String url;
     private final String iconUrl;
 }

--- a/module-api/src/main/java/com/mile/exception/log/discord/model/EmbedObject.java
+++ b/module-api/src/main/java/com/mile/exception/log/discord/model/EmbedObject.java
@@ -1,4 +1,4 @@
-package com.mile.log.discord.model;
+package com.mile.exception.log.discord.model;
 
 import java.awt.Color;
 import java.util.ArrayList;

--- a/module-api/src/main/java/com/mile/exception/log/discord/model/Field.java
+++ b/module-api/src/main/java/com/mile/exception/log/discord/model/Field.java
@@ -1,4 +1,4 @@
-package com.mile.log.discord.model;
+package com.mile.exception.log.discord.model;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/module-api/src/main/java/com/mile/exception/log/discord/model/Footer.java
+++ b/module-api/src/main/java/com/mile/exception/log/discord/model/Footer.java
@@ -1,13 +1,12 @@
-package com.mile.log.discord.model;
+package com.mile.exception.log.discord.model;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class Author {
+public class Footer {
 
-    private final String name;
-    private final String url;
+    private final String text;
     private final String iconUrl;
 }

--- a/module-api/src/main/java/com/mile/exception/log/discord/model/Image.java
+++ b/module-api/src/main/java/com/mile/exception/log/discord/model/Image.java
@@ -1,11 +1,12 @@
-package com.mile.log.discord.model;
+package com.mile.exception.log.discord.model;
+
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class Thumbnail {
+public class Image {
 
     private final String url;
 }

--- a/module-api/src/main/java/com/mile/exception/log/discord/model/JsonObject.java
+++ b/module-api/src/main/java/com/mile/exception/log/discord/model/JsonObject.java
@@ -1,4 +1,4 @@
-package com.mile.log.discord.model;
+package com.mile.exception.log.discord.model;
 
 import java.lang.reflect.Array;
 import java.util.HashMap;

--- a/module-api/src/main/java/com/mile/exception/log/discord/model/Thumbnail.java
+++ b/module-api/src/main/java/com/mile/exception/log/discord/model/Thumbnail.java
@@ -1,12 +1,11 @@
-package com.mile.log.discord.model;
-
+package com.mile.exception.log.discord.model;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class Image {
+public class Thumbnail {
 
     private final String url;
 }

--- a/module-api/src/main/java/com/mile/exception/log/filter/CustomServletWrappingFilter.java
+++ b/module-api/src/main/java/com/mile/exception/log/filter/CustomServletWrappingFilter.java
@@ -1,6 +1,6 @@
-package com.mile.log.filter;
+package com.mile.exception.log.filter;
 
-import com.mile.log.filter.wrapper.CachedBodyRequestWrapper;
+import com.mile.exception.log.filter.wrapper.CachedBodyRequestWrapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/module-api/src/main/java/com/mile/exception/log/filter/FilterConfig.java
+++ b/module-api/src/main/java/com/mile/exception/log/filter/FilterConfig.java
@@ -1,4 +1,4 @@
-package com.mile.log.filter;
+package com.mile.exception.log.filter;
 
 
 import org.springframework.boot.web.servlet.FilterRegistrationBean;

--- a/module-api/src/main/java/com/mile/exception/log/filter/MDCFilter.java
+++ b/module-api/src/main/java/com/mile/exception/log/filter/MDCFilter.java
@@ -1,7 +1,7 @@
-package com.mile.log.filter;
+package com.mile.exception.log.filter;
 
-import com.mile.log.utils.HttpRequestUtil;
-import com.mile.log.utils.MDCUtil;
+import com.mile.exception.log.utils.HttpRequestUtil;
+import com.mile.exception.log.utils.MDCUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/module-api/src/main/java/com/mile/exception/log/filter/wrapper/CachedBodyRequestWrapper.java
+++ b/module-api/src/main/java/com/mile/exception/log/filter/wrapper/CachedBodyRequestWrapper.java
@@ -1,4 +1,4 @@
-package com.mile.log.filter.wrapper;
+package com.mile.exception.log.filter.wrapper;
 
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;

--- a/module-api/src/main/java/com/mile/exception/log/filter/wrapper/CachedBodyServletInputStream.java
+++ b/module-api/src/main/java/com/mile/exception/log/filter/wrapper/CachedBodyServletInputStream.java
@@ -1,4 +1,4 @@
-package com.mile.log.filter.wrapper;
+package com.mile.exception.log.filter.wrapper;
 
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletInputStream;

--- a/module-api/src/main/java/com/mile/exception/log/utils/ApiCallUtil.java
+++ b/module-api/src/main/java/com/mile/exception/log/utils/ApiCallUtil.java
@@ -1,4 +1,4 @@
-package com.mile.log.utils;
+package com.mile.exception.log.utils;
 
 
 import java.io.IOException;
@@ -6,7 +6,7 @@ import java.io.OutputStream;
 import java.net.URL;
 import javax.net.ssl.HttpsURLConnection;
 
-import com.mile.log.discord.model.JsonObject;
+import com.mile.exception.log.discord.model.JsonObject;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/module-api/src/main/java/com/mile/exception/log/utils/HttpRequestConfig.java
+++ b/module-api/src/main/java/com/mile/exception/log/utils/HttpRequestConfig.java
@@ -1,6 +1,6 @@
-package com.mile.log.utils;
+package com.mile.exception.log.utils;
 
-import com.mile.log.filter.CustomServletWrappingFilter;
+import com.mile.exception.log.filter.CustomServletWrappingFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/module-api/src/main/java/com/mile/exception/log/utils/HttpRequestUtil.java
+++ b/module-api/src/main/java/com/mile/exception/log/utils/HttpRequestUtil.java
@@ -1,7 +1,7 @@
-package com.mile.log.utils;
+package com.mile.exception.log.utils;
 
 
-import com.mile.log.filter.wrapper.CachedBodyRequestWrapper;
+import com.mile.exception.log.filter.wrapper.CachedBodyRequestWrapper;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AccessLevel;

--- a/module-api/src/main/java/com/mile/exception/log/utils/MDCUtil.java
+++ b/module-api/src/main/java/com/mile/exception/log/utils/MDCUtil.java
@@ -1,4 +1,4 @@
-package com.mile.log.utils;
+package com.mile.exception.log.utils;
 
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/module-api/src/main/java/com/mile/exception/log/utils/StringUtil.java
+++ b/module-api/src/main/java/com/mile/exception/log/utils/StringUtil.java
@@ -1,4 +1,4 @@
-package com.mile.log.utils;
+package com.mile.exception.log.utils;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/module-api/src/main/resources/discord-appender.xml
+++ b/module-api/src/main/resources/discord-appender.xml
@@ -1,5 +1,5 @@
 <included>
-    <appender name="DISCORD" class="com.mile.log.discord.DiscordAppender">
+    <appender name="DISCORD" class="com.mile.exception.log.discord.DiscordAppender">
         <discordWebhookUrl>${DISCORD_WEBHOOK_URI}</discordWebhookUrl>
         <username>에러났대...</username>
         <avatarUrl>https://www.greenart.co.kr/upimage/new_editor/20212/20210201112021.jpg</avatarUrl>

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -4,6 +4,4 @@ jar { enabled = true }
 dependencies {
     //Aop
     implementation 'org.springframework.boot:spring-boot-starter-aop'
-    //Sentry
-    implementation 'io.sentry:sentry-spring-boot-starter-jakarta:7.9.0'
 }

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -134,7 +134,7 @@ public class MoimService {
         return MoimMostCuriousWriterResponse.of(writers);
     }
 
-    public MoimMostCuriousWriterResponse getMoistCuriousWritersOfMoimForTotal(
+    public MoimMostCuriousWriterResponse getMostCuriousWritersOfMoimForTotal(
             final Moim moim
     ) {
         List<WriterName> writerNames = writerNameRetriever.findTop2ByCuriousCount(moim);
@@ -178,7 +178,7 @@ public class MoimService {
     public MoimOverallInfoResponse getMoimTotalInformation(final Long moimId) {
         Moim moim = moimRetriever.findById(moimId);
         MoimInfoResponse moimInfoResponse = getMoimInfoForTotal(moim);
-        MoimMostCuriousWriterResponse mostCuriousWriterResponse = getMoistCuriousWritersOfMoimForTotal(moim);
+        MoimMostCuriousWriterResponse mostCuriousWriterResponse = getMostCuriousWritersOfMoimForTotal(moim);
         MoimCuriousPostListResponse moimCuriousPostListResponse = postRetriever.getMostCuriousPostByMoimForTotal(moim);
         return new MoimOverallInfoResponse(moimInfoResponse, moimCuriousPostListResponse, mostCuriousWriterResponse);
     }

--- a/module-domain/src/main/java/com/mile/moim/service/MoimService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/MoimService.java
@@ -4,27 +4,28 @@ import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.BadRequestException;
 import com.mile.exception.model.ForbiddenException;
 import com.mile.moim.domain.Moim;
+import com.mile.moim.service.dto.request.MoimCreateRequest;
+import com.mile.moim.service.dto.request.MoimInfoModifyRequest;
+import com.mile.moim.service.dto.request.TopicCreateRequest;
+import com.mile.moim.service.dto.request.WriterMemberJoinRequest;
 import com.mile.moim.service.dto.response.BestMoimListResponse;
 import com.mile.moim.service.dto.response.ContentListResponse;
 import com.mile.moim.service.dto.response.InvitationCodeGetResponse;
 import com.mile.moim.service.dto.response.MoimAuthenticateResponse;
-import com.mile.moim.service.dto.request.MoimCreateRequest;
 import com.mile.moim.service.dto.response.MoimCreateResponse;
 import com.mile.moim.service.dto.response.MoimCuriousPostListResponse;
-import com.mile.moim.service.dto.request.MoimInfoModifyRequest;
 import com.mile.moim.service.dto.response.MoimInfoOwnerResponse;
 import com.mile.moim.service.dto.response.MoimInfoResponse;
 import com.mile.moim.service.dto.response.MoimInvitationInfoResponse;
+import com.mile.moim.service.dto.response.MoimMostCuriousWriterResponse;
 import com.mile.moim.service.dto.response.MoimNameConflictCheckResponse;
+import com.mile.moim.service.dto.response.MoimOverallInfoResponse;
 import com.mile.moim.service.dto.response.MoimPublicStatusResponse;
 import com.mile.moim.service.dto.response.MoimTopicInfoListResponse;
 import com.mile.moim.service.dto.response.MoimTopicResponse;
 import com.mile.moim.service.dto.response.MoimWriterNameListGetResponse;
-import com.mile.moim.service.dto.response.PopularWriterListResponse;
 import com.mile.moim.service.dto.response.TemporaryPostExistResponse;
-import com.mile.moim.service.dto.request.TopicCreateRequest;
 import com.mile.moim.service.dto.response.TopicListResponse;
-import com.mile.moim.service.dto.request.WriterMemberJoinRequest;
 import com.mile.moim.service.dto.response.WriterNameConflictCheckResponse;
 import com.mile.moim.service.lock.AtomicValidateUniqueMoimName;
 import com.mile.post.domain.Post;
@@ -125,11 +126,19 @@ public class MoimService {
         return MoimAuthenticateResponse.of(writerNameRetriever.isUserInMoim(moimId, userId), moimRetriever.isMoimOwnerEqualsUser(moimRetriever.findById(moimId), userId));
     }
 
-    public PopularWriterListResponse getMostCuriousWritersOfMoim(
+    public MoimMostCuriousWriterResponse getMostCuriousWritersOfMoim(
             final Long moimId
     ) {
-        List<WriterName> writers = writerNameRetriever.findTop2ByCuriousCount(moimId);
-        return PopularWriterListResponse.of(writers);
+        Moim moim = moimRetriever.findById(moimId);
+        List<WriterName> writers = writerNameRetriever.findTop2ByCuriousCount(moim);
+        return MoimMostCuriousWriterResponse.of(writers);
+    }
+
+    public MoimMostCuriousWriterResponse getMoistCuriousWritersOfMoimForTotal(
+            final Moim moim
+    ) {
+        List<WriterName> writerNames = writerNameRetriever.findTop2ByCuriousCount(moim);
+        return MoimMostCuriousWriterResponse.of(writerNames);
     }
 
 
@@ -153,8 +162,30 @@ public class MoimService {
         );
     }
 
+    public MoimInfoResponse getMoimInfoForTotal(
+            final Moim moim
+    ) {
+        return MoimInfoResponse.of(
+                moim.getImageUrl(),
+                moim.getName(),
+                moim.getOwner().getName(),
+                moim.getInformation(),
+                writerNameRetriever.findNumbersOfWritersByMoim(moim),
+                DateUtil.getStringDateOfLocalDate(moim.getCreatedAt())
+        );
+    }
+
+    public MoimOverallInfoResponse getMoimTotalInformation(final Long moimId) {
+        Moim moim = moimRetriever.findById(moimId);
+        MoimInfoResponse moimInfoResponse = getMoimInfoForTotal(moim);
+        MoimMostCuriousWriterResponse mostCuriousWriterResponse = getMoistCuriousWritersOfMoimForTotal(moim);
+        MoimCuriousPostListResponse moimCuriousPostListResponse = postRetriever.getMostCuriousPostByMoimForTotal(moim);
+        return new MoimOverallInfoResponse(moimInfoResponse, moimCuriousPostListResponse, mostCuriousWriterResponse);
+    }
+
     public MoimCuriousPostListResponse getMostCuriousPostFromMoim(final Long moimId) {
-        return postRetriever.getMostCuriousPostByMoim(moimRetriever.findById(moimId));
+        Moim moim = moimRetriever.findById(moimId);
+        return postRetriever.getMostCuriousPostByMoim(moim);
     }
 
     public TopicListResponse getTopicList(

--- a/module-domain/src/main/java/com/mile/moim/service/dto/response/MoimMostCuriousWriterResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/response/MoimMostCuriousWriterResponse.java
@@ -5,10 +5,10 @@ import com.mile.writername.service.dto.response.PopularWriterResponse;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public record PopularWriterListResponse(List<PopularWriterResponse> popularWriters) {
+public record MoimMostCuriousWriterResponse(List<PopularWriterResponse> popularWriters) {
 
-    public static PopularWriterListResponse of(final List<WriterName> writers) {
-        return new PopularWriterListResponse(
+    public static MoimMostCuriousWriterResponse of(final List<WriterName> writers) {
+        return new MoimMostCuriousWriterResponse(
                 writers
                 .stream()
                 .map(PopularWriterResponse::of)

--- a/module-domain/src/main/java/com/mile/moim/service/dto/response/MoimOverallInfoResponse.java
+++ b/module-domain/src/main/java/com/mile/moim/service/dto/response/MoimOverallInfoResponse.java
@@ -1,0 +1,8 @@
+package com.mile.moim.service.dto.response;
+
+public record MoimOverallInfoResponse(
+        MoimInfoResponse infoResponse,
+        MoimCuriousPostListResponse mostCuriousPost,
+        MoimMostCuriousWriterResponse mostCuriousWriter
+) {
+}

--- a/module-domain/src/main/java/com/mile/post/service/PostRetriever.java
+++ b/module-domain/src/main/java/com/mile/post/service/PostRetriever.java
@@ -130,7 +130,6 @@ public class PostRetriever {
         return post.getWriterName().equals(writerName);
     }
 
-
     public MoimCuriousPostListResponse getMostCuriousPostByMoim(final Moim moim) {
         List<Post> postList = getPostHaveCuriousCount(postRepository.findTop2ByMoimOrderByCuriousCountDesc(moim));
         return MoimCuriousPostListResponse.of(postList
@@ -138,6 +137,15 @@ public class PostRetriever {
                 .map(p ->
                         MoimMostCuriousPostResponse.of(p.getIdUrl(), p.getImageUrl(), p.getTopic().getContent(), p.getTitle(), p.getContent(), p.isContainPhoto())
                 ).collect(Collectors.toList()));
+    }
+
+    public MoimCuriousPostListResponse getMostCuriousPostByMoimForTotal(final Moim moim) {
+        List<Post> postList = getPostHaveCuriousCount(postRepository.findTop2ByMoimOrderByCuriousCountDesc(moim));
+        return MoimCuriousPostListResponse.of(
+                postList.stream()
+                        .map((p ->
+                        MoimMostCuriousPostResponse.of(p.getIdUrl(), p.getImageUrl(), p.getTopic().getContent(), p.getTitle(), p.getContent(), p.isContainPhoto())
+                )).toList());
     }
 
     public int findPostCountByWriterNameId(

--- a/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
+++ b/module-domain/src/main/java/com/mile/writername/repository/WriterNameRepository.java
@@ -27,7 +27,9 @@ public interface WriterNameRepository extends JpaRepository<WriterName, Long> {
 
     boolean existsWriterNameByMoimAndNormalizedName(final Moim moim, final String normalizedName);
 
-    List<WriterName> findTop2ByMoimIdAndTotalCuriousCountGreaterThanOrderByTotalCuriousCountDesc(final Long moimId, final int totalCuriousCount);
+    int countByMoim(final Moim moim);
+
+    List<WriterName> findTop2ByMoimAndTotalCuriousCountGreaterThanOrderByTotalCuriousCountDesc(final Moim moim, final int totalCuriousCount);
 
     @Query("SELECT w FROM WriterName w WHERE w.moim.id = :moimId ORDER BY CASE WHEN w = :owner THEN 0 ELSE 1 END, w.id ASC")
     Page<WriterName> findByMoimIdOrderByOwnerFirstAndIdAsc(@Param("moimId") Long moimId, @Param("owner") WriterName owner, Pageable pageable);

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameRetriever.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameRetriever.java
@@ -114,8 +114,14 @@ public class WriterNameRetriever {
         return writerNameRepository.findByMoimId(moimId).size();
     }
 
-    public List<WriterName> findTop2ByCuriousCount(final Long moimid) {
-        return writerNameRepository.findTop2ByMoimIdAndTotalCuriousCountGreaterThanOrderByTotalCuriousCountDesc(moimid, MIN_TOTAL_CURIOUS_COUNT);
+    public int findNumbersOfWritersByMoim(
+            final Moim moim
+    ) {
+        return writerNameRepository.countByMoim(moim);
+    }
+
+    public List<WriterName> findTop2ByCuriousCount(final Moim moim) {
+        return writerNameRepository.findTop2ByMoimAndTotalCuriousCountGreaterThanOrderByTotalCuriousCountDesc(moim, MIN_TOTAL_CURIOUS_COUNT);
     }
 
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #504 

## Key Changes 🔑
1. 슬랙에서 API 통합 논의가 나와서 먼저 구현을 해놓았습니다! 이 후에 사용하지 않는 API를 삭제하는 방향으로 수정하면 될 것 같습니다!
2. 그리고 logging에 info level(예외가 아닌 요청)도 로깅할 수 있게(tps를 보는데 효과적) 수정하면서 logging의 경우 presentation 계층(왜냐하면 요청이 들어오면서 로깅시작, 끝나면 로깅 종료이기 때문)에 속한다고 판단하여 예외 로깅 및 global exception handler(사용자에게 예외를 보내기 위함) 또한 api 모듈로 이동하였습니다.

## To Reviewers 📢
-
