### PR TITLE
#511 [feat] 에러코드 요청에 따른 수정

### DIFF
--- a/module-api/src/main/java/com/mile/common/resolver/comment/CommentVariableResolver.java
+++ b/module-api/src/main/java/com/mile/common/resolver/comment/CommentVariableResolver.java
@@ -3,6 +3,7 @@ package com.mile.common.resolver.comment;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.BadRequestException;
 import com.mile.common.utils.SecureUrlUtil;
+import com.mile.exception.model.NotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -36,7 +37,7 @@ public class CommentVariableResolver implements HandlerMethodArgumentResolver {
         try {
             return secureUrlUtil.decodeUrl(id);
         } catch (NumberFormatException e) {
-            throw new BadRequestException(ErrorMessage.INVALID_URL_EXCEPTION);
+            throw new NotFoundException(ErrorMessage.INVALID_URL_EXCEPTION);
         }
     }
 }

--- a/module-api/src/main/java/com/mile/common/resolver/moim/MoimVariableResolver.java
+++ b/module-api/src/main/java/com/mile/common/resolver/moim/MoimVariableResolver.java
@@ -3,6 +3,7 @@ package com.mile.common.resolver.moim;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.BadRequestException;
 import com.mile.common.utils.SecureUrlUtil;
+import com.mile.exception.model.NotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -36,7 +37,7 @@ public class MoimVariableResolver implements HandlerMethodArgumentResolver {
         try {
             return secureUrlUtil.decodeUrl(moimId);
         } catch (NumberFormatException e) {
-            throw new BadRequestException(ErrorMessage.INVALID_URL_EXCEPTION);
+            throw new NotFoundException(ErrorMessage.INVALID_URL_EXCEPTION);
         }
     }
 }

--- a/module-api/src/main/java/com/mile/common/resolver/post/PostVariableResolver.java
+++ b/module-api/src/main/java/com/mile/common/resolver/post/PostVariableResolver.java
@@ -3,6 +3,7 @@ package com.mile.common.resolver.post;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.BadRequestException;
 import com.mile.common.utils.SecureUrlUtil;
+import com.mile.exception.model.NotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -35,7 +36,7 @@ public class PostVariableResolver implements HandlerMethodArgumentResolver {
         try {
             return secureUrlUtil.decodeUrl(postId);
         } catch (NumberFormatException e) {
-            throw new BadRequestException(ErrorMessage.INVALID_URL_EXCEPTION);
+            throw new NotFoundException(ErrorMessage.INVALID_URL_EXCEPTION);
         }
     }
 }

--- a/module-api/src/main/java/com/mile/common/resolver/reply/ReplyVariableResolver.java
+++ b/module-api/src/main/java/com/mile/common/resolver/reply/ReplyVariableResolver.java
@@ -3,6 +3,7 @@ package com.mile.common.resolver.reply;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.BadRequestException;
 import com.mile.common.utils.SecureUrlUtil;
+import com.mile.exception.model.NotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -36,7 +37,7 @@ public class ReplyVariableResolver implements HandlerMethodArgumentResolver {
         try {
             return secureUrlUtil.decodeUrl(replyId);
         } catch (NumberFormatException e) {
-            throw new BadRequestException(ErrorMessage.INVALID_URL_EXCEPTION);
+            throw new NotFoundException(ErrorMessage.INVALID_URL_EXCEPTION);
         }
     }
 }

--- a/module-api/src/main/java/com/mile/common/resolver/topic/TopicVariableResolver.java
+++ b/module-api/src/main/java/com/mile/common/resolver/topic/TopicVariableResolver.java
@@ -3,6 +3,7 @@ package com.mile.common.resolver.topic;
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.BadRequestException;
 import com.mile.common.utils.SecureUrlUtil;
+import com.mile.exception.model.NotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -36,7 +37,7 @@ public class TopicVariableResolver implements HandlerMethodArgumentResolver {
         try {
             return secureUrlUtil.decodeUrl(topicId);
         } catch (NumberFormatException e) {
-            throw new BadRequestException(ErrorMessage.INVALID_URL_EXCEPTION);
+            throw new NotFoundException(ErrorMessage.INVALID_URL_EXCEPTION);
         }
     }
 }

--- a/module-api/src/test/java/com/mile/controller/MoimControllerTest.java
+++ b/module-api/src/test/java/com/mile/controller/MoimControllerTest.java
@@ -65,7 +65,7 @@ public class MoimControllerTest {
     private static final String AUTHORIZATION = "Authorization";
     private static final int OK = 200;
     private static final int CREATED = 201;
-    private static final int BAD_REQUEST = 400;
+    private static final int NOT_FOUND = 404;
     private static Long USER_ID;
     private static String MOIM_ID;
     private static String randomString;
@@ -132,7 +132,7 @@ public class MoimControllerTest {
         ).andDo(print()).andReturn();
 
         //then
-        assertThat(result.getResponse().getStatus()).isEqualTo(BAD_REQUEST);
+        assertThat(result.getResponse().getStatus()).isEqualTo(NOT_FOUND);
 
     }
 

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -21,8 +21,7 @@ public enum ErrorMessage {
     CURIOUS_NOT_FOUND(40407, "해당 궁금해요는 존재하지 않습니다."),
     TOPIC_NOT_FOUND(40408, "글감이 존재하지 않습니다."),
     RECOMMEND_NOT_FOUND(40412, "추천 글감을 받아오는데 실패했습니다."),
-    PATH_PARAMETER_INVALID_ERROR(40413, "해당 URI는 자원을 표시할 수 없습니다."),
-    INVALID_URL_EXCEPTION(40414, "해당 URI는 자원을 표시할 수 없습니다."),
+    INVALID_URL_EXCEPTION(40413, "해당 URI는 자원을 표시할 수 없습니다."),
     /*
     Bad Request
      */

--- a/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
+++ b/module-common/src/main/java/com/mile/exception/message/ErrorMessage.java
@@ -19,12 +19,10 @@ public enum ErrorMessage {
     HANDLER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "요청하신 URL은 정보가 없습니다."),
     COMMENT_NOT_FOUND(40406, "해당 댓글이 존재하지 않습니다."),
     CURIOUS_NOT_FOUND(40407, "해당 궁금해요는 존재하지 않습니다."),
-    TOPIC_NOT_FOUND(40408, "해당 글감이 존재하지 않습니다."),
-    KEYWORD_NOT_FOUND(40409, "해당 글모임의 글감 키워드가 존재하지 않습니다."),
-    WRITER_NOT_FOUND(40411, "해당 작가는 존재하지 않습니다."),
+    TOPIC_NOT_FOUND(40408, "글감이 존재하지 않습니다."),
     RECOMMEND_NOT_FOUND(40412, "추천 글감을 받아오는데 실패했습니다."),
-    MOIM_TOPIC_NOT_FOUND(40413, "해당 모임의 글감이 존재하지 않습니다."),
-    REPLY_NOT_FOUND(40416, "Id에 해당하는 대댓글이 없습니다."),
+    PATH_PARAMETER_INVALID_ERROR(40413, "해당 URI는 자원을 표시할 수 없습니다."),
+    INVALID_URL_EXCEPTION(40414, "해당 URI는 자원을 표시할 수 없습니다."),
     /*
     Bad Request
      */
@@ -38,11 +36,9 @@ public enum ErrorMessage {
     BEARER_LOST_ERROR(HttpStatus.BAD_REQUEST.value(), "토큰의 요청에 Bearer이 담겨 있지 않습니다."),
     POST_NOT_TEMPORARY_ERROR(40008, "해당 글은 임시저장 글이 아닙니다."),
     POST_TEMPORARY_ERROR(HttpStatus.BAD_REQUEST.value(), "해당 글은 임시저장글입니다."),
-    PATH_PARAMETER_INVALID_ERROR(40010, "해당 URI는 자원을 표시할 수 없습니다."),
     REQUEST_URL_WRONG_ERROR(HttpStatus.BAD_REQUEST.value(), "요청 URL를 다시 확인해주세요"),
     IMAGE_EXTENSION_INVALID_ERROR(HttpStatus.BAD_REQUEST.value(), "이미지 확장자는 jpg, png, webp만 가능합니다."),
     IMAGE_SIZE_INVALID_ERROR(HttpStatus.BAD_REQUEST.value(), "이미지 사이즈는 5MB를 넘을 수 없습니다."),
-    INVALID_URL_EXCEPTION(40014, "해당 URI는 자원을 표시할 수 없습니다."),
     LEAST_TOPIC_SIZE_OF_MOIM_ERROR(40015, "모임에는 최소 하나의 글감이 있어야 합니다."),
     USER_MOIM_ALREADY_JOIN(40016, "사용자는 이미 모임에 가입했습니다."),
     WRITER_NAME_LENGTH_WRONG(40017, "사용 불가능한 필명입니다."),

--- a/module-domain/src/main/java/com/mile/commentreply/service/CommentReplyRetriever.java
+++ b/module-domain/src/main/java/com/mile/commentreply/service/CommentReplyRetriever.java
@@ -26,7 +26,7 @@ public class CommentReplyRetriever {
             final Long replyId
     ) {
         return commentReplyRepository.findById(replyId).orElseThrow(
-                () -> new NotFoundException(ErrorMessage.REPLY_NOT_FOUND)
+                () -> new NotFoundException(ErrorMessage.COMMENT_NOT_FOUND)
         );
     }
 

--- a/module-domain/src/main/java/com/mile/common/utils/SecureUrlUtil.java
+++ b/module-domain/src/main/java/com/mile/common/utils/SecureUrlUtil.java
@@ -18,7 +18,7 @@ public class SecureUrlUtil {
         try {
             return Long.parseLong(new String(Base64.getUrlDecoder().decode(url)));
         } catch (IllegalArgumentException e) {
-            throw new NotFoundException(ErrorMessage.PATH_PARAMETER_INVALID_ERROR);
+            throw new NotFoundException(ErrorMessage.INVALID_URL_EXCEPTION);
         }
     }
 

--- a/module-domain/src/main/java/com/mile/common/utils/SecureUrlUtil.java
+++ b/module-domain/src/main/java/com/mile/common/utils/SecureUrlUtil.java
@@ -2,6 +2,7 @@ package com.mile.common.utils;
 
 import com.mile.exception.message.ErrorMessage;
 import com.mile.exception.model.BadRequestException;
+import com.mile.exception.model.NotFoundException;
 import org.springframework.stereotype.Component;
 
 import java.util.Base64;
@@ -17,7 +18,7 @@ public class SecureUrlUtil {
         try {
             return Long.parseLong(new String(Base64.getUrlDecoder().decode(url)));
         } catch (IllegalArgumentException e) {
-            throw new BadRequestException(ErrorMessage.PATH_PARAMETER_INVALID_ERROR);
+            throw new NotFoundException(ErrorMessage.PATH_PARAMETER_INVALID_ERROR);
         }
     }
 

--- a/module-domain/src/main/java/com/mile/topic/service/TopicRetriever.java
+++ b/module-domain/src/main/java/com/mile/topic/service/TopicRetriever.java
@@ -141,7 +141,7 @@ public class TopicRetriever {
             final List<Topic> topicList
     ) {
         if (topicList.isEmpty()) {
-            throw new NotFoundException(ErrorMessage.KEYWORD_NOT_FOUND);
+            throw new NotFoundException(ErrorMessage.TOPIC_NOT_FOUND);
         }
     }
 
@@ -186,7 +186,7 @@ public class TopicRetriever {
     ) {
         return topicRepository.findLatestTopicByMoim(moim)
                 .orElseThrow(
-                        () -> new NotFoundException(ErrorMessage.MOIM_TOPIC_NOT_FOUND)
+                        () -> new NotFoundException(ErrorMessage.TOPIC_NOT_FOUND)
                 );
     }
 

--- a/module-domain/src/main/java/com/mile/writername/service/WriterNameRetriever.java
+++ b/module-domain/src/main/java/com/mile/writername/service/WriterNameRetriever.java
@@ -37,7 +37,7 @@ public class WriterNameRetriever {
 
     public WriterName findById(final Long id) {
         return writerNameRepository.findById(id).orElseThrow(
-                () -> new NotFoundException(ErrorMessage.WRITER_NOT_FOUND)
+                () -> new NotFoundException(ErrorMessage.USER_NOT_FOUND)
         );
     }
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #511 

## Key Changes 🔑
변경된 에러코드 아카이빙용으로 적어놓겠습니다!
- 글감이 존재하지 않을 때 발생했던 에러 40408, 40409, 40413 -> 40408로 통일
- 댓글이 존재하지 않을 때, 대댓글이 존재하지 않을 때 발생하는 에러코드 40406으로 통일
- 필명이 존재하지 않을 때 -> 유저가 존재하지 않는 것으로 에러코드 통일 40400
- PathVariable (요청 URI가 존재하지 않을 때) 40014, 40010 -> 40413으로 통일


## To Reviewers 📢
-
