### PR TITLE
#564 [feat] sql 로깅 모듈 구현

### DIFF
--- a/module-domain/src/main/java/com/mile/common/log/P6spySqlFormat.java
+++ b/module-domain/src/main/java/com/mile/common/log/P6spySqlFormat.java
@@ -1,0 +1,33 @@
+package com.mile.common.log;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.slf4j.MDC;
+
+import java.util.Locale;
+
+public class P6spySqlFormat implements MessageFormattingStrategy {
+    private final String MDC_KEY = "SQL_START";
+
+    @Override
+    public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared, String sql, String url) {
+        sql = formatSql(category, sql);
+        return MDC.get(MDC_KEY) + "|" + sql;
+    }
+
+    private String formatSql(String category, String sql) {
+        if (sql == null || sql.trim().equals("")) return sql;
+
+        if (Category.STATEMENT.getName().equals(category)) {
+            String tmpsql = sql.trim().toLowerCase(Locale.ROOT);
+            if (tmpsql.startsWith("create") || tmpsql.startsWith("alter") || tmpsql.startsWith("comment")) {
+                sql = FormatStyle.DDL.getFormatter().format(sql);
+            } else {
+                sql = FormatStyle.BASIC.getFormatter().format(sql);
+            }
+        }
+
+        return sql;
+    }
+}

--- a/module-domain/src/main/java/com/mile/common/log/P6spySqlFormatConfig.java
+++ b/module-domain/src/main/java/com/mile/common/log/P6spySqlFormatConfig.java
@@ -1,0 +1,14 @@
+package com.mile.common.log;
+
+import com.p6spy.engine.spy.P6SpyOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class P6spySqlFormatConfig {
+
+    @PostConstruct
+    public void setLogMessageFormat() {
+        P6SpyOptions.getActiveInstance().setLogMessageFormat(P6spySqlFormat.class.getName());
+    }
+}

--- a/module-domain/src/main/java/com/mile/common/log/SqlFunctionLoggingModule.java
+++ b/module-domain/src/main/java/com/mile/common/log/SqlFunctionLoggingModule.java
@@ -1,0 +1,35 @@
+package com.mile.common.log;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+/**
+ * from @sohyundoh
+ * <p>
+ * SQL 진입점을 로깅하기 위한 AOP 클래스
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
+public class SqlFunctionLoggingModule {
+    private final String MDC_KEY = "SQL_START";
+
+    @Pointcut("execution(* com.mile.*.repository..*.*(..))")
+    public void sqlLoggingPoint() {
+    }
+
+    @Around("sqlLoggingPoint()")
+    public Object putSqlStartingPoint(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MDC.put(MDC_KEY, "[ QUERY START -> " + joinPoint.getSignature().toShortString() + "]");
+
+        return joinPoint.proceed();
+    }
+}

--- a/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
+++ b/module-domain/src/main/java/com/mile/moim/repository/MoimRepository.java
@@ -1,7 +1,6 @@
 package com.mile.moim.repository;
 
 import com.mile.moim.domain.Moim;
-import com.mile.post.domain.Post;
 import com.mile.writername.domain.WriterName;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #564 

## Key Changes 🔑
1. p6spy로 sql 문의 인자 포함된 로깅을 제공하고, 이를 포맷한 후 진입점을 로깅할 수 있게 AOP 방식으로 repository 내부 메서드 호출 시 MDC에 진입점을 담도록 진행했습니다. 그리고 이를 logging formatter에서 꺼내오도록했습니다.
2. 이 때 MDC.get 값은 경우는 null 인 경우를 보장해주어서 NPE 나는 경우를 걱정하지 않아도 될 것이라고 판단했습니다.
![image](https://github.com/user-attachments/assets/7d7e16cb-a891-483b-b94f-a5f27464722e)
결과는 아래와 같습니다!
![image](https://github.com/user-attachments/assets/c8eccac1-4afa-400b-a902-ecfcafd117ac)

## To Reviewers 📢
-
