### PR TITLE
#580 [feat] 리프레시 토큰 만료시 500 에러 아닌 에러 타도록 수정

### DIFF
--- a/module-api/src/main/java/com/mile/common/auth/JwtTokenProvider.java
+++ b/module-api/src/main/java/com/mile/common/auth/JwtTokenProvider.java
@@ -123,6 +123,10 @@ public class JwtTokenProvider {
     }
 
     public HashMap<Long, WriterNameInfo> getJoinedRoleFromJwt(final String token) {
+
+        if(!validateToken(token).equals(JwtValidationType.VALID_JWT)) {
+            throw new UnauthorizedException(ErrorMessage.TOKEN_INCORRECT_ERROR);
+        }
         Claims claims = getBody(token);
         Object joinedRole = claims.get(JOINED_ROLE);
         HashMap<Long, WriterNameInfo> roleMap = objectMapper.convertValue(joinedRole, new TypeReference<HashMap<Long, WriterNameInfo>>() {});

--- a/module-api/src/main/java/com/mile/common/auth/JwtTokenProvider.java
+++ b/module-api/src/main/java/com/mile/common/auth/JwtTokenProvider.java
@@ -123,10 +123,6 @@ public class JwtTokenProvider {
     }
 
     public HashMap<Long, WriterNameInfo> getJoinedRoleFromJwt(final String token) {
-
-        if(!validateToken(token).equals(JwtValidationType.VALID_JWT)) {
-            throw new UnauthorizedException(ErrorMessage.TOKEN_INCORRECT_ERROR);
-        }
         Claims claims = getBody(token);
         Object joinedRole = claims.get(JOINED_ROLE);
         HashMap<Long, WriterNameInfo> roleMap = objectMapper.convertValue(joinedRole, new TypeReference<HashMap<Long, WriterNameInfo>>() {});

--- a/module-api/src/main/java/com/mile/controller/user/facade/AuthFacade.java
+++ b/module-api/src/main/java/com/mile/controller/user/facade/AuthFacade.java
@@ -4,7 +4,9 @@ package com.mile.controller.user.facade;
 import com.mile.client.SocialType;
 import com.mile.client.dto.UserLoginRequest;
 import com.mile.common.auth.JwtTokenProvider;
-import com.mile.writername.domain.MoimRole;
+import com.mile.common.auth.JwtValidationType;
+import com.mile.exception.message.ErrorMessage;
+import com.mile.exception.model.UnauthorizedException;
 import com.mile.jwt.service.TokenService;
 import com.mile.moim.service.dto.response.MoimListOfUserResponse;
 import com.mile.strategy.LoginStrategyManager;
@@ -34,6 +36,10 @@ public class AuthFacade {
             final String refreshToken
     ) {
         final Long userId = tokenService.findIdByRefreshToken(refreshToken);
+
+        if(jwtTokenProvider.validateToken(refreshToken).equals(JwtValidationType.VALID_JWT)) {
+            throw new UnauthorizedException(ErrorMessage.TOKEN_INCORRECT_ERROR);
+        }
         final Map<Long, WriterNameInfo> role = jwtTokenProvider.getJoinedRoleFromJwt(refreshToken);
 
         return AccessTokenGetSuccess.of(


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #580 
- 
## Key Changes 🔑
1. Refresh Token이 만료되면 500에러가 발생하여서 수정하고, 머지하면서 prod yml 수정하겠습니다!
## To Reviewers 📢
-
