### PR TITLE
#581 [feat] 글모임 정보 받아올 시 분산락 위치 변경

### DIFF
--- a/module-domain/src/main/java/com/mile/moim/service/popular/MoimPopularInfoRegister.java
+++ b/module-domain/src/main/java/com/mile/moim/service/popular/MoimPopularInfoRegister.java
@@ -58,7 +58,7 @@ public class MoimPopularInfoRegister {
 
         moimPopularInfoRepository.saveAndFlush(moimPopularInfo);
 
-        distributedLock.afterLock("MOIM_POPULAR_LOCK");
+        distributedLock.afterLock("MOIM_POPULAR_LOCK" + moim.getId());
 
         return moimPopularInfo;
     }

--- a/module-domain/src/main/java/com/mile/moim/service/popular/MoimPopularInfoRegister.java
+++ b/module-domain/src/main/java/com/mile/moim/service/popular/MoimPopularInfoRegister.java
@@ -47,7 +47,6 @@ public class MoimPopularInfoRegister {
 
     @CachePut(value = "moimPopularInfo", key = "#moim.id")
     public MoimPopularInfo setMostPopularInfoOfMoim(final Moim moim) {
-        distributedLock.getLock("MOIM_POPULAR_LOCK");
 
         List<PostAndCuriousCountInLastWeek> mostCuriousPostsInLastWeek = curiousRetriever.findMostCuriousPostsInLastWeek(moim);
 

--- a/module-domain/src/main/java/com/mile/moim/service/popular/MoimPopularInfoService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/popular/MoimPopularInfoService.java
@@ -26,7 +26,7 @@ public class MoimPopularInfoService {
     public MoimPopularInfo getMoimPopularInfo(final Moim moim) {
         return moimPopularInfoRepository.findByMoimId(moim.getId()).orElseGet(
                 () -> {
-                    distributedLock.getLock("MOIM_POPULAR_LOCK");
+                    distributedLock.getLock("MOIM_POPULAR_LOCK" + moim.getId());
                     return moimPopularInfoRegister.setMostPopularInfoOfMoim(moim);
                 }
         );

--- a/module-domain/src/main/java/com/mile/moim/service/popular/MoimPopularInfoService.java
+++ b/module-domain/src/main/java/com/mile/moim/service/popular/MoimPopularInfoService.java
@@ -1,6 +1,7 @@
 package com.mile.moim.service.popular;
 
 import com.mile.common.CacheService;
+import com.mile.common.lock.DistributedLock;
 import com.mile.moim.domain.Moim;
 import com.mile.moim.domain.popular.MoimPopularInfo;
 import com.mile.moim.repository.MoimPopularInfoRepository;
@@ -17,13 +18,17 @@ public class MoimPopularInfoService {
     private final MoimPopularInfoRepository moimPopularInfoRepository;
     private final MoimPopularInfoRegister moimPopularInfoRegister;
     private final SendMessageModule sendMessageModule;
+    private final DistributedLock distributedLock;
     private final CacheService cacheService;
 
 
     @Cacheable(value = "moimPopularInfo", key = "#moim.id")
     public MoimPopularInfo getMoimPopularInfo(final Moim moim) {
         return moimPopularInfoRepository.findByMoimId(moim.getId()).orElseGet(
-                () -> moimPopularInfoRegister.setMostPopularInfoOfMoim(moim)
+                () -> {
+                    distributedLock.getLock("MOIM_POPULAR_LOCK");
+                    return moimPopularInfoRegister.setMostPopularInfoOfMoim(moim);
+                }
         );
     }
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #581 

## Key Changes 🔑
1. 글모임 인기 정보 관련 set이 들어갈 때, register를 접근해서 하는 것이 아닌, register 밖에서 lock을 획득하려고 한 뒤에 획득하면 접근하도록 변경했습니다. (캐시의 동시성을 보장하기 위해)
2. 분산락 키가 공통이어서 , 모든 요청에 대해 모임 구분 없이 락을 걸고 있었는데, 모임별로 분산락을 걸도록 수정했습니다.
## To Reviewers 📢
-
